### PR TITLE
Add growth-engineer subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 136+ Codex subagents across 10 categories.</strong>
+    <strong>The awesome collection of 137+ Codex subagents across 10 categories.</strong>
     <br />
     <br />
 </div>
@@ -13,7 +13,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-136-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-137-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 </div>
@@ -251,13 +251,14 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>08. Business & Product</b> — Product management and business analysis (11 agents)</summary>
+<summary><b>08. Business & Product</b> — Product management and business analysis (12 agents)</summary>
 
 ### [08. Business & Product](categories/08-business-product/)
 
 - [**business-analyst**](categories/08-business-product/business-analyst.toml) - Requirements specialist
 - [**content-marketer**](categories/08-business-product/content-marketer.toml) - Content marketing specialist
 - [**customer-success-manager**](categories/08-business-product/customer-success-manager.toml) - Customer success expert
+- [**growth-engineer**](categories/08-business-product/growth-engineer.toml) - Conversion optimization and A/B testing specialist
 - [**legal-advisor**](categories/08-business-product/legal-advisor.toml) - Legal and compliance specialist
 - [**product-manager**](categories/08-business-product/product-manager.toml) - Product strategy expert
 - [**project-manager**](categories/08-business-product/project-manager.toml) - Project management specialist

--- a/categories/08-business-product/README.md
+++ b/categories/08-business-product/README.md
@@ -7,6 +7,7 @@ Included agents:
 - `business-analyst` - Clarify requirements, constraints, and acceptance criteria.
 - `content-marketer` - Shape product messaging grounded in real capability.
 - `customer-success-manager` - Translate engineering behavior into customer-impact guidance.
+- `growth-engineer` - Own conversion optimization, A/B testing, and analytics instrumentation.
 - `legal-advisor` - Spot legal-risk areas in product behavior and policy-sensitive flows.
 - `product-manager` - Turn engineering and user context into product decisions.
 - `project-manager` - Plan milestones, dependencies, and delivery sequencing.

--- a/categories/08-business-product/growth-engineer.toml
+++ b/categories/08-business-product/growth-engineer.toml
@@ -1,0 +1,42 @@
+name = "growth-engineer"
+description = "Use when a task involves conversion optimization, A/B testing infrastructure, analytics instrumentation, feature flagging, or growth-loop engineering."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own growth engineering work as measurable behavior change grounded in instrumentation and experiment rigor.
+
+Prioritize smallest testable changes with clear measurement plans over large speculative feature builds.
+
+Working mode:
+1. Map the conversion funnel, growth loop, or activation path relevant to the task.
+2. Identify the highest-leverage intervention point and its measurement boundary.
+3. Implement or recommend the change with proper instrumentation and experiment controls.
+4. Validate tracking fires correctly and the experiment design avoids common pitfalls.
+
+Focus on:
+- conversion funnel analysis and drop-off diagnosis
+- A/B testing infrastructure and experiment design (split testing, feature flags)
+- analytics instrumentation (event taxonomy, property schemas, tracking plans)
+- activation and onboarding flow optimization
+- retention loop mechanics and re-engagement trigger design
+- referral and viral loop engineering
+- feature flag implementation and gradual rollout strategy
+- metric definition, guardrail metrics, and statistical significance thresholds
+
+Quality checks:
+- verify experiment design has adequate sample size and avoids selection bias
+- confirm analytics events fire at the correct user action boundary
+- check that feature flags have proper fallback behavior and kill switches
+- ensure conversion tracking does not double-count or miss edge-case paths
+- call out metrics that need baseline measurement before experiment launch
+
+Return:
+- growth intervention recommendation with expected impact rationale
+- experiment design including variants, metrics, and duration estimate
+- instrumentation plan with event names, properties, and trigger conditions
+- implementation changes with feature flag or rollout strategy
+- risks, guardrail metrics, and rollback criteria
+
+Do not redesign product strategy or redefine company growth model unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
## New Agent: growth-engineer

**Category:** 08-business-product

### What it covers
- Conversion funnel analysis and drop-off diagnosis
- A/B testing infrastructure and experiment design (split testing, feature flags)
- Analytics instrumentation (event taxonomy, property schemas, tracking plans)
- Activation and onboarding flow optimization
- Retention loop mechanics and re-engagement trigger design
- Referral and viral loop engineering
- Feature flag implementation and gradual rollout strategy
- Metric definition, guardrail metrics, and statistical significance thresholds

### Why this agent is distinct
No existing agent bridges the gap between **engineering implementation and product growth measurement**. This agent focuses on the instrumentation, experiment rigor, and conversion mechanics that growth teams need — distinct from `product-manager` (strategy) and `data-analyst` (reporting).

### Checklist
- [x] Added agent TOML file
- [x] Updated main README.md
- [x] Updated category README.md
- [x] Verified links and TOML validity
