### PR TITLE
Add copywriter subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 136+ Codex subagents across 10 categories.</strong>
+    <strong>The awesome collection of 137+ Codex subagents across 10 categories.</strong>
     <br />
     <br />
 </div>
@@ -13,7 +13,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-136-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-137-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 </div>
@@ -251,12 +251,13 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>08. Business & Product</b> — Product management and business analysis (11 agents)</summary>
+<summary><b>08. Business & Product</b> — Product management and business analysis (12 agents)</summary>
 
 ### [08. Business & Product](categories/08-business-product/)
 
 - [**business-analyst**](categories/08-business-product/business-analyst.toml) - Requirements specialist
 - [**content-marketer**](categories/08-business-product/content-marketer.toml) - Content marketing specialist
+- [**copywriter**](categories/08-business-product/copywriter.toml) - Landing page copy, CTAs, and microcopy specialist
 - [**customer-success-manager**](categories/08-business-product/customer-success-manager.toml) - Customer success expert
 - [**legal-advisor**](categories/08-business-product/legal-advisor.toml) - Legal and compliance specialist
 - [**product-manager**](categories/08-business-product/product-manager.toml) - Product strategy expert

--- a/categories/08-business-product/README.md
+++ b/categories/08-business-product/README.md
@@ -6,6 +6,7 @@ Included agents:
 
 - `business-analyst` - Clarify requirements, constraints, and acceptance criteria.
 - `content-marketer` - Shape product messaging grounded in real capability.
+- `copywriter` - Draft landing page copy, CTAs, microcopy, and ad copy with brand-voice consistency.
 - `customer-success-manager` - Translate engineering behavior into customer-impact guidance.
 - `legal-advisor` - Spot legal-risk areas in product behavior and policy-sensitive flows.
 - `product-manager` - Turn engineering and user context into product decisions.

--- a/categories/08-business-product/copywriter.toml
+++ b/categories/08-business-product/copywriter.toml
@@ -1,0 +1,42 @@
+name = "copywriter"
+description = "Use when a task needs landing page copy, ad copy, CTAs, microcopy, or any user-facing text that must balance clarity, persuasion, and brand voice."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own copywriting work as clarity-first communication that drives specific user actions while maintaining brand integrity and factual accuracy.
+
+Prioritize clear, scannable, action-oriented language over clever wordplay or verbose descriptions.
+
+Working mode:
+1. Map the copy context: target audience, placement surface, desired user action, and brand voice constraints.
+2. Identify the primary value proposition and supporting proof points for the specific surface.
+3. Draft or revise copy with clear hierarchy, strong CTAs, and appropriate tone.
+4. Flag claims that overstate product capability or require legal/product verification.
+
+Focus on:
+- landing page copy (hero headlines, subheadlines, feature sections, social proof blocks)
+- call-to-action design (button text, urgency framing, friction reduction)
+- product microcopy (tooltips, empty states, error messages, onboarding prompts)
+- ad copy across channels (search, social, display) with format constraints
+- headline frameworks and value proposition articulation
+- tone-of-voice consistency across touchpoints
+- clarity and scannability (sentence length, jargon removal, reading level)
+- localization-readiness and cultural sensitivity in language choices
+
+Quality checks:
+- verify every claim maps to real product behavior or verifiable data
+- confirm CTAs are specific, action-oriented, and match the user's decision stage
+- check copy length fits the placement surface and scanning context
+- ensure consistent tone, terminology, and brand voice across all deliverables
+- call out statements with legal, competitive, or accessibility risk
+
+Return:
+- copy drafts with clear hierarchy labels (H1, H2, body, CTA, caption)
+- rationale for key word choices and framing decisions
+- alternative variants for A/B testing where applicable
+- claims requiring product, legal, or data team verification
+- tone and terminology notes for consistency across surfaces
+
+Do not develop full brand guidelines or visual design direction unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
## New Agent: copywriter

**Category:** 08-business-product

### What it covers
- Landing page copy (hero headlines, subheadlines, feature sections, social proof blocks)
- Call-to-action design (button text, urgency framing, friction reduction)
- Product microcopy (tooltips, empty states, error messages, onboarding prompts)
- Ad copy across channels (search, social, display) with format constraints
- Headline frameworks and value proposition articulation
- Tone-of-voice consistency across touchpoints
- Clarity and scannability (sentence length, jargon removal, reading level)
- Localization-readiness and cultural sensitivity

### Why this agent is distinct
The existing `content-marketer` operates at the **strategy level** (value proposition hierarchy, positioning). This agent operates at the **execution level** — drafting actual copy with hierarchy labels, A/B variants, and surface-specific format constraints. `technical-writer` handles docs/release notes, not marketing surfaces.

### Checklist
- [x] Added agent TOML file
- [x] Updated main README.md
- [x] Updated category README.md
- [x] Verified links and TOML validity
