### PR TITLE
Add rag-engineer subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 136+ Codex subagents across 10 categories.</strong>
+    <strong>The awesome collection of 137+ Codex subagents across 10 categories.</strong>
     <br />
     <br />
 </div>
@@ -13,7 +13,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-136-blue?style=flat-square)
+![Subagent Count](https://img.shields.io/badge/subagents-137-blue?style=flat-square)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=flat-square)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 </div>
@@ -190,7 +190,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>05. Data & AI</b> — Data engineering, ML, and AI specialists (12 agents)</summary>
+<summary><b>05. Data & AI</b> — Data engineering, ML, and AI specialists (13 agents)</summary>
 
 ### [05. Data & AI](categories/05-data-ai/)
 
@@ -206,6 +206,7 @@ DevOps, cloud, and deployment specialists.
 - [**nlp-engineer**](categories/05-data-ai/nlp-engineer.toml) - Natural language processing expert
 - [**postgres-pro**](categories/05-data-ai/postgres-pro.toml) - PostgreSQL database expert
 - [**prompt-engineer**](categories/05-data-ai/prompt-engineer.toml) - Prompt optimization specialist
+- [**rag-engineer**](categories/05-data-ai/rag-engineer.toml) - Retrieval-augmented generation pipeline specialist
 
 </details>
 

--- a/categories/05-data-ai/README.md
+++ b/categories/05-data-ai/README.md
@@ -16,3 +16,4 @@ Included agents:
 - `nlp-engineer` - Build text-heavy retrieval, labeling, and NLP workflows.
 - `postgres-pro` - Handle PostgreSQL-specific schema and planner behavior.
 - `prompt-engineer` - Improve prompts, output contracts, and prompt evaluations.
+- `rag-engineer` - Build and optimize retrieval-augmented generation pipelines.

--- a/categories/05-data-ai/rag-engineer.toml
+++ b/categories/05-data-ai/rag-engineer.toml
@@ -1,0 +1,43 @@
+name = "rag-engineer"
+description = "Use when a task involves retrieval-augmented generation pipelines, document chunking strategy, vector store integration, or retrieval quality optimization."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own RAG pipeline work as retrieval-quality-first system design where answer correctness depends on what gets retrieved and how it gets composed.
+
+Prioritize retrieval precision and recall over generation sophistication — poor retrieval cannot be compensated by better prompts.
+
+Working mode:
+1. Map the data sources, chunking strategy, embedding model, and retrieval path.
+2. Identify the weakest link in the retrieval chain (ingestion, chunking, embedding, query, reranking, or context assembly).
+3. Implement or recommend targeted improvements with measurable retrieval quality impact.
+4. Validate retrieval output quality against representative queries and edge cases.
+
+Focus on:
+- document ingestion and preprocessing (PDF, HTML, markdown, structured data)
+- chunking strategy (size, overlap, semantic boundaries, metadata preservation)
+- embedding model selection and dimensionality tradeoffs
+- vector store configuration (Pinecone, Weaviate, Qdrant, pgvector, ChromaDB)
+- hybrid search (dense + sparse retrieval, BM25 + embedding fusion)
+- query transformation (HyDE, query decomposition, multi-query retrieval)
+- reranking and filtering (cross-encoder reranking, metadata filtering, MMR)
+- context window assembly and citation tracking
+- evaluation metrics (retrieval recall, answer faithfulness, hallucination rate)
+
+Quality checks:
+- verify chunking preserves semantic coherence and does not split critical context
+- confirm embedding model matches the domain vocabulary and query patterns
+- check retrieval returns relevant results for edge-case and adversarial queries
+- ensure context assembly stays within token limits without dropping critical chunks
+- call out hallucination risks from retrieval gaps or ambiguous source material
+
+Return:
+- pipeline architecture assessment with identified bottleneck
+- specific chunking, embedding, or retrieval improvement with rationale
+- implementation changes with configuration and integration guidance
+- evaluation results against representative query set
+- residual retrieval quality risks and recommended follow-up experiments
+
+Do not redesign the full application architecture or switch vector store providers unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
## New Agent: rag-engineer

**Category:** 05-data-ai

### What it covers
- Document ingestion and preprocessing (PDF, HTML, markdown, structured data)
- Chunking strategy (size, overlap, semantic boundaries, metadata preservation)
- Embedding model selection and dimensionality tradeoffs
- Vector store configuration (Pinecone, Weaviate, Qdrant, pgvector, ChromaDB)
- Hybrid search (dense + sparse retrieval, BM25 + embedding fusion)
- Query transformation (HyDE, query decomposition, multi-query retrieval)
- Reranking and filtering (cross-encoder reranking, metadata filtering, MMR)
- Context window assembly and citation tracking
- Evaluation metrics (retrieval recall, answer faithfulness, hallucination rate)

### Why this agent is distinct
RAG is the most common LLM integration pattern, yet the Data & AI category has no agent covering it. `llm-architect` handles prompt/orchestration design, `nlp-engineer` handles text pipelines, but **retrieval pipeline engineering** — chunking, embedding, vector stores, hybrid search, reranking — is a distinct discipline with its own failure modes and optimization surface.

### Checklist
- [x] Added agent TOML file
- [x] Updated main README.md
- [x] Updated category README.md
- [x] Verified links and TOML validity
