### PR TITLE
Add skillfold pipeline compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,7 @@ DevOps, cloud, and deployment specialists.
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.toml) - Advanced multi-agent orchestration
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.toml) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
+- [**skillfold**](https://github.com/byronxlg/skillfold) - Pipeline compiler: compile a YAML config into Codex subagent files and 10 other platform formats (Claude Code, Cursor, Copilot, Gemini, and more)
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.toml) - Task allocation specialist
 - [**workflow-orchestrator**](categories/09-meta-orchestration/workflow-orchestrator.toml) - Complex workflow automation
 


### PR DESCRIPTION
Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Meta & Orchestration section.

Skillfold is a YAML-based configuration language and compiler for multi-agent AI pipelines. It compiles a single config file into Codex subagent files and 10 other platform formats (Claude Code, Cursor, Copilot, Gemini, Windsurf, Goose, Roo Code, Kiro, Junie, Agent Teams). It handles skill composition, typed state schemas, execution flow graphs with conditional routing and parallel map, and orchestrator generation.

Placed after `pied-piper` in the Meta & Orchestration section, following the same external-link format used for that entry (it's a tool, not a `.toml` file).

## Checklist

- [x] Entry placed in correct section (09. Meta & Orchestration)
- [x] Follows the same external-link list format as pied-piper
- [x] Description is concise and factual
- [x] Repository is public and accessible
- [x] No duplicate entries