### PR TITLE
Add product-manager-skills to Business & Product

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ DevOps, cloud, and deployment specialists.
 - [**customer-success-manager**](categories/08-business-product/customer-success-manager.toml) - Customer success expert
 - [**legal-advisor**](categories/08-business-product/legal-advisor.toml) - Legal and compliance specialist
 - [**product-manager**](categories/08-business-product/product-manager.toml) - Product strategy expert
+- [**product-manager-skills**](https://github.com/Digidai/product-manager-skills) - Senior PM agent with 6 knowledge domains, 30+ frameworks, 32 SaaS metrics, 12 templates, anti-pattern detection (Claude Code skill, pure Markdown)
 - [**project-manager**](categories/08-business-product/project-manager.toml) - Project management specialist
 - [**sales-engineer**](categories/08-business-product/sales-engineer.toml) - Technical sales expert
 - [**scrum-master**](categories/08-business-product/scrum-master.toml) - Agile methodology expert


### PR DESCRIPTION
Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Business & Product category alongside the existing product-manager subagent.

This is a comprehensive PM agent skill for Claude Code with 6 knowledge domains, 30+ frameworks, 32 SaaS metrics with formulas, 12 templates, and anti-pattern detection. Pure Markdown, MIT-0 license.

Complements the existing product-manager.toml by offering deeper coverage of PM frameworks and metrics.