### PR TITLE
Add ToolRouter — 150+ tools for Codex agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ DevOps, cloud, and deployment specialists.
 - [**performance-monitor**](categories/09-meta-orchestration/performance-monitor.toml) - Agent performance optimization
 - [**pied-piper**](https://github.com/sathish316/pied-piper/) - Orchestrate Team of AI Subagents for repetitive SDLC workflows
 - [**task-distributor**](categories/09-meta-orchestration/task-distributor.toml) - Task allocation specialist
+- [**toolrouter**](https://toolrouter.com) - Give your Codex agent superpowers — 150+ tools on demand with one account. Competitor research, video production, web search, image generation, security scanning, and more. `npx -y toolrouter-mcp`
 - [**workflow-orchestrator**](categories/09-meta-orchestration/workflow-orchestrator.toml) - Complex workflow automation
 
 </details>

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -13,4 +13,5 @@ Included agents:
 - `multi-agent-coordinator` - Design explicit multi-agent task plans.
 - `performance-monitor` - Turn performance signals into actionable summaries.
 - `task-distributor` - Break broad work into concrete delegated tasks.
+- `toolrouter` - 150+ tools on demand with one account via MCP. `npx -y toolrouter-mcp`
 - `workflow-orchestrator` - Design explicit delegation flows for larger tasks.


### PR DESCRIPTION
Adds ToolRouter — give your Codex agent access to 150+ tools on demand with one account. One API key replaces managing dozens of provider accounts.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Setup: `codex mcp add toolrouter -- npx -y toolrouter-mcp`