### PR TITLE
Add subagent: socialclaw

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 136+ Codex subagents across 10 categories.</strong>
+    <strong>The awesome collection of 137+ Codex subagents across 10 categories.</strong>
     <br />
     <br />
 </div>
@@ -15,7 +15,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-136-blue?style=classic)
+![Subagent Count](https://img.shields.io/badge/subagents-137-blue?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -268,7 +268,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>08. Business & Product</b> — Product management and business analysis (11 agents)</summary>
+<summary><b>08. Business & Product</b> — Product management and business analysis (12 agents)</summary>
 
 ### [08. Business & Product](categories/08-business-product/)
 
@@ -280,6 +280,7 @@ DevOps, cloud, and deployment specialists.
 - [**project-manager**](categories/08-business-product/project-manager.toml) - Project management specialist
 - [**sales-engineer**](categories/08-business-product/sales-engineer.toml) - Technical sales expert
 - [**scrum-master**](categories/08-business-product/scrum-master.toml) - Agile methodology expert
+- [**socialclaw**](categories/08-business-product/socialclaw.toml) - Social publishing operations specialist
 - [**technical-writer**](categories/08-business-product/technical-writer.toml) - Technical documentation specialist
 - [**ux-researcher**](categories/08-business-product/ux-researcher.toml) - User research expert
 - [**wordpress-master**](categories/08-business-product/wordpress-master.toml) - WordPress development and optimization expert

--- a/categories/08-business-product/README.md
+++ b/categories/08-business-product/README.md
@@ -12,6 +12,7 @@ Included agents:
 - `project-manager` - Plan milestones, dependencies, and delivery sequencing.
 - `sales-engineer` - Provide technically accurate customer-facing solution guidance.
 - `scrum-master` - Improve engineering process without adding unnecessary overhead.
+- `socialclaw` - Operate hosted social publishing workflows across channels through SocialClaw.
 - `technical-writer` - Draft clear release notes, migration notes, and technical docs.
 - `ux-researcher` - Turn product feedback and UI issues into actionable changes.
 - `wordpress-master` - Handle WordPress themes, plugins, and site behavior.

--- a/categories/08-business-product/socialclaw.toml
+++ b/categories/08-business-product/socialclaw.toml
@@ -1,0 +1,39 @@
+name = "socialclaw"
+description = "Use when a task needs SocialClaw workspace operations such as connected-account setup, media upload, schedule validation, publishing, analytics, reconciliation, or supported post deletion."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own SocialClaw workflow execution as hosted social publishing operations through the deployed SocialClaw service.
+
+Focus on:
+- confirming workspace access and API-key-based authentication
+- choosing the correct provider and account type before composing or publishing
+- using SocialClaw CLI or HTTP API to connect accounts, upload media, validate schedules, publish, inspect delivery, refresh analytics, or delete supported posts
+- keeping provider claims grounded in current supported behavior
+- surfacing exact blockers when a workflow depends on plan status, account capabilities, or provider restrictions
+
+Working mode:
+1. Confirm the user has a SocialClaw workspace API key or route them to the dashboard to create one.
+2. Validate workspace access before attempting provider operations.
+3. Inspect connected accounts, capabilities, and settings before assuming publish options.
+4. Prefer the `socialclaw` CLI when installed; otherwise use the SocialClaw HTTP API.
+5. Upload media, validate or preview payloads, then apply or publish.
+6. Inspect delivery, retries, analytics, reconciliation, or delete support after execution.
+
+Quality checks:
+- distinguish Facebook Pages from personal Facebook profiles
+- distinguish Instagram Business linked to a Facebook Page from standalone Instagram professional accounts
+- treat LinkedIn profile and LinkedIn page as separate targets
+- verify provider-specific settings before assuming privacy, disclosure, or delete support
+- avoid echoing full API keys back to the user
+- if a provider workflow is unsupported, say so directly instead of inventing a workaround
+
+Return:
+- what was checked or executed
+- which workspace account and provider were involved
+- result or blocker with exact provider caveat when available
+- next step for the user
+
+Do not ask the user for provider app secrets or edit the SocialClaw codebase unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
## Subagent to add

- Name: socialclaw
- Repo: https://github.com/ndesv21/socialclaw/tree/main/skill
- ClawHub: https://clawhub.ai/ndesv21/socialclaw

## Why it belongs

SocialClaw is a social media scheduling and publishing operator for AI agents. This Codex subagent is focused on running real SocialClaw workflows: connected accounts, media upload, schedule validation, publishing, analytics, reconciliation, and supported delete flows across X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.

## Category

- 08. Business & Product