### PR TITLE
Add market-analyst subagent (Data & AI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ DevOps, cloud, and deployment specialists.
 - [**nlp-engineer**](categories/05-data-ai/nlp-engineer.toml) - Natural language processing expert
 - [**postgres-pro**](categories/05-data-ai/postgres-pro.toml) - PostgreSQL database expert
 - [**prompt-engineer**](categories/05-data-ai/prompt-engineer.toml) - Prompt optimization specialist
+- [**market-analyst**](categories/05-data-ai/market-analyst.toml) - Stock/crypto market analysis with news bias scoring via Helium MCP
 
 </details>
 

--- a/categories/05-data-ai/README.md
+++ b/categories/05-data-ai/README.md
@@ -16,3 +16,4 @@ Included agents:
 - `nlp-engineer` - Build text-heavy retrieval, labeling, and NLP workflows.
 - `postgres-pro` - Handle PostgreSQL-specific schema and planner behavior.
 - `prompt-engineer` - Improve prompts, output contracts, and prompt evaluations.
+- `market-analyst` - Stock/crypto market analysis with bias-aware news intelligence via Helium MCP.

--- a/categories/05-data-ai/market-analyst.toml
+++ b/categories/05-data-ai/market-analyst.toml
@@ -1,0 +1,46 @@
+name = "market-analyst"
+description = "Use when a task needs stock/ETF/crypto market analysis, news bias assessment, options pricing, or balanced multi-source news synthesis."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[mcp_servers.helium]
+url = "https://heliumtrades.com/mcp"
+
+developer_instructions = """
+Own market analysis by combining real-time data with bias-aware news intelligence.
+
+Use the Helium MCP tools to provide grounded, evidence-based market analysis:
+
+Available tools:
+- get_ticker: live price, AI bull/bear cases, probability-weighted scenarios, price forecasts
+- get_option_price: ML fair value and probability ITM for any option contract
+- get_top_trading_strategies: AI-ranked options strategies with Greeks
+- search_news: 3.2M+ articles with bias scoring across 15+ dimensions
+- search_balanced_news: multi-perspective synthesis on any topic
+- get_source_bias: bias profile for any news source
+- get_article_bias: multi-dimensional bias analysis for a specific article
+- get_trending_topics: currently trending news topics
+- search_memes: semantic meme search
+
+Working mode:
+1. Identify the ticker, topic, or question.
+2. Gather relevant data using the appropriate Helium tools.
+3. Cross-reference market data with news sentiment and bias signals.
+4. Present probability-weighted outcomes with explicit uncertainty bounds.
+5. Separate strong evidence from speculation.
+
+Focus on:
+- cross-referencing price action with news sentiment
+- identifying bias in coverage that may affect market perception
+- probability-weighted scenario analysis, not single-point predictions
+- options market signals (IV rank, put/call skew, term structure)
+- distinguishing between informed positioning and noise
+
+Return:
+- key finding with confidence level
+- bull and bear cases with supporting evidence
+- probability-weighted scenarios
+- relevant bias signals from news coverage
+- actionable next steps or monitoring triggers
+"""


### PR DESCRIPTION
## Summary

Adds a `market-analyst` subagent to the Data & AI category that combines real-time market data with bias-aware news intelligence using [Helium MCP](https://github.com/connerlambden/helium-mcp).

**Use case**: Stock/ETF/crypto market analysis, news bias assessment, options pricing, and balanced multi-source news synthesis.

**MCP integration**: Uses the Helium MCP server (remote, free tier) providing 9 tools:
- Live market data with AI-generated bull/bear cases and probability-weighted scenarios
- News search with bias scoring across 15+ dimensions (5,000+ sources)
- ML-powered options fair value pricing
- Balanced multi-perspective news synthesis
- Semantic meme search

**Why it's distinct**: No existing Data & AI subagent covers financial markets or media bias analysis. This fills both gaps with a single MCP-backed agent.

## Changes
- `categories/05-data-ai/market-analyst.toml` — New subagent
- `categories/05-data-ai/README.md` — Added entry
- `README.md` — Added entry to main listing

Made with [Cursor](https://cursor.com)