### PR TITLE
Update subagent GPT models

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,8 @@ Avoid:
 
 ## Model and Sandbox Guidance
 
-- Prefer `gpt-5.4` for complex reasoning/review roles.
-- Prefer `gpt-5.3-codex-spark` for lighter search/synthesis roles.
+- Prefer `gpt-5.5` for complex reasoning/review roles.
+- Prefer `gpt-5.4-mini` for lighter search/synthesis roles.
 - Use `read-only` by default for review/research agents.
 - Use `workspace-write` only when the agent must implement changes.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Each subagent uses a Codex-native `.toml` format:
 ```toml
 name = "subagent-name"
 description = "When this agent should be invoked"
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 
@@ -100,8 +100,8 @@ Each subagent includes a `model` field that automatically routes it to the right
 
 | Model | When It's Used | Examples |
 |-------|----------------|----------|
-| `gpt-5.4` | Deep reasoning -- architecture reviews, security audits, financial logic | `security-auditor`, `architect-reviewer`, `fintech-engineer` |
-| `gpt-5.3-codex-spark` | Fast scanning, synthesis, and lighter research tasks | `search-specialist`, `docs-researcher`, `agent-installer` |
+| `gpt-5.5` | Deep reasoning -- architecture reviews, security audits, financial logic | `security-auditor`, `architect-reviewer`, `fintech-engineer` |
+| `gpt-5.4-mini` | Fast scanning, synthesis, and lighter research tasks | `search-specialist`, `docs-researcher`, `agent-installer` |
 
 ### Sandbox Mode Philosophy
 

--- a/categories/01-core-development/api-designer.toml
+++ b/categories/01-core-development/api-designer.toml
@@ -1,6 +1,6 @@
 name = "api-designer"
 description = "Use when a task needs API contract design, evolution planning, or compatibility review before implementation starts."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/backend-developer.toml
+++ b/categories/01-core-development/backend-developer.toml
@@ -1,6 +1,6 @@
 name = "backend-developer"
 description = "Use when a task needs scoped backend implementation or backend bug fixes after the owning path is known."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/code-mapper.toml
+++ b/categories/01-core-development/code-mapper.toml
@@ -1,6 +1,6 @@
 name = "code-mapper"
 description = "Use when the parent agent needs a high-confidence map of code paths, ownership boundaries, and execution flow before changes are made."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/electron-pro.toml
+++ b/categories/01-core-development/electron-pro.toml
@@ -1,6 +1,6 @@
 name = "electron-pro"
 description = "Use when a task needs Electron-specific implementation or debugging across main/renderer/preload boundaries, packaging, and desktop runtime behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/frontend-developer.toml
+++ b/categories/01-core-development/frontend-developer.toml
@@ -1,6 +1,6 @@
 name = "frontend-developer"
 description = "Use when a task needs scoped frontend implementation or UI bug fixes with production-level behavior and quality."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/fullstack-developer.toml
+++ b/categories/01-core-development/fullstack-developer.toml
@@ -1,6 +1,6 @@
 name = "fullstack-developer"
 description = "Use when one bounded feature or bug spans frontend and backend and a single worker should own the entire path."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/graphql-architect.toml
+++ b/categories/01-core-development/graphql-architect.toml
@@ -1,6 +1,6 @@
 name = "graphql-architect"
 description = "Use when a task needs GraphQL schema evolution, resolver architecture, federation design, or distributed graph performance/security review."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/microservices-architect.toml
+++ b/categories/01-core-development/microservices-architect.toml
@@ -1,6 +1,6 @@
 name = "microservices-architect"
 description = "Use when a task needs service-boundary design, inter-service contract review, or distributed-system architecture decisions."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/mobile-developer.toml
+++ b/categories/01-core-development/mobile-developer.toml
@@ -1,6 +1,6 @@
 name = "mobile-developer"
 description = "Use when a task needs mobile implementation or debugging across app lifecycle, API integration, and device/platform-specific UX constraints."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/ui-designer.toml
+++ b/categories/01-core-development/ui-designer.toml
@@ -1,6 +1,6 @@
 name = "ui-designer"
 description = "Use when a task needs concrete UI decisions, interaction design, and implementation-ready design guidance before or during development."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/ui-fixer.toml
+++ b/categories/01-core-development/ui-fixer.toml
@@ -1,6 +1,6 @@
 name = "ui-fixer"
 description = "Use when a UI issue is already reproduced and the parent agent wants the smallest safe patch."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/websocket-engineer.toml
+++ b/categories/01-core-development/websocket-engineer.toml
@@ -1,6 +1,6 @@
 name = "websocket-engineer"
 description = "Use when a task needs real-time transport and state work across WebSocket lifecycle, message contracts, and reconnect/failure behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/angular-architect.toml
+++ b/categories/02-language-specialists/angular-architect.toml
@@ -1,6 +1,6 @@
 name = "angular-architect"
 description = "Use when a task needs Angular-specific help for component architecture, dependency injection, routing, signals, or enterprise application structure."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/cpp-pro.toml
+++ b/categories/02-language-specialists/cpp-pro.toml
@@ -1,6 +1,6 @@
 name = "cpp-pro"
 description = "Use when a task needs C++ work involving performance-sensitive code, memory ownership, concurrency, or systems-level integration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/csharp-developer.toml
+++ b/categories/02-language-specialists/csharp-developer.toml
@@ -1,6 +1,6 @@
 name = "csharp-developer"
 description = "Use when a task needs C# or .NET application work involving services, APIs, async flows, or application architecture."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/django-developer.toml
+++ b/categories/02-language-specialists/django-developer.toml
@@ -1,6 +1,6 @@
 name = "django-developer"
 description = "Use when a task needs Django-specific work across models, views, forms, ORM behavior, or admin and middleware flows."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/dotnet-core-expert.toml
+++ b/categories/02-language-specialists/dotnet-core-expert.toml
@@ -1,6 +1,6 @@
 name = "dotnet-core-expert"
 description = "Use when a task needs modern .NET and ASP.NET Core expertise for APIs, hosting, middleware, or cross-platform application behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/dotnet-framework-4.8-expert.toml
+++ b/categories/02-language-specialists/dotnet-framework-4.8-expert.toml
@@ -1,6 +1,6 @@
 name = "dotnet-framework-4.8-expert"
 description = "Use when a task needs .NET Framework 4.8 expertise for legacy enterprise applications, compatibility constraints, or Windows-bound integrations."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/elixir-expert.toml
+++ b/categories/02-language-specialists/elixir-expert.toml
@@ -1,6 +1,6 @@
 name = "elixir-expert"
 description = "Use when a task needs Elixir and OTP expertise for processes, supervision, fault tolerance, or Phoenix application behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/erlang-expert.toml
+++ b/categories/02-language-specialists/erlang-expert.toml
@@ -1,6 +1,6 @@
 name = "erlang-expert"
 description = "Use when a task needs Erlang/OTP and rebar3 expertise for BEAM processes, testing, releases, upgrades, or distributed runtime behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/flutter-expert.toml
+++ b/categories/02-language-specialists/flutter-expert.toml
@@ -1,6 +1,6 @@
 name = "flutter-expert"
 description = "Use when a task needs Flutter expertise for widget behavior, state management, rendering issues, or mobile cross-platform implementation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/golang-pro.toml
+++ b/categories/02-language-specialists/golang-pro.toml
@@ -1,6 +1,6 @@
 name = "golang-pro"
 description = "Use when a task needs Go expertise for concurrency, service implementation, interfaces, tooling, or performance-sensitive backend paths."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/java-architect.toml
+++ b/categories/02-language-specialists/java-architect.toml
@@ -1,6 +1,6 @@
 name = "java-architect"
 description = "Use when a task needs Java application or service architecture help across framework boundaries, JVM behavior, or large codebase structure."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/javascript-pro.toml
+++ b/categories/02-language-specialists/javascript-pro.toml
@@ -1,6 +1,6 @@
 name = "javascript-pro"
 description = "Use when a task needs JavaScript-focused work for runtime behavior, browser or Node execution, or application-level code that is not TypeScript-led."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/kotlin-specialist.toml
+++ b/categories/02-language-specialists/kotlin-specialist.toml
@@ -1,6 +1,6 @@
 name = "kotlin-specialist"
 description = "Use when a task needs Kotlin expertise for JVM applications, Android code, coroutines, or modern strongly typed service logic."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/laravel-specialist.toml
+++ b/categories/02-language-specialists/laravel-specialist.toml
@@ -1,6 +1,6 @@
 name = "laravel-specialist"
 description = "Use when a task needs Laravel-specific work across routing, Eloquent, queues, validation, or application structure."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/nextjs-developer.toml
+++ b/categories/02-language-specialists/nextjs-developer.toml
@@ -1,6 +1,6 @@
 name = "nextjs-developer"
 description = "Use when a task needs Next.js-specific work across routing, rendering modes, server actions, data fetching, or deployment-sensitive frontend behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/php-pro.toml
+++ b/categories/02-language-specialists/php-pro.toml
@@ -1,6 +1,6 @@
 name = "php-pro"
 description = "Use when a task needs PHP expertise for application logic, framework integration, runtime debugging, or server-side code evolution."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/powershell-5.1-expert.toml
+++ b/categories/02-language-specialists/powershell-5.1-expert.toml
@@ -1,6 +1,6 @@
 name = "powershell-5.1-expert"
 description = "Use when a task needs Windows PowerShell 5.1 expertise for legacy automation, full .NET Framework interop, or Windows administration scripts."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/powershell-7-expert.toml
+++ b/categories/02-language-specialists/powershell-7-expert.toml
@@ -1,6 +1,6 @@
 name = "powershell-7-expert"
 description = "Use when a task needs modern PowerShell 7 expertise for cross-platform automation, scripting, or .NET-based operational tooling."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/python-pro.toml
+++ b/categories/02-language-specialists/python-pro.toml
@@ -1,6 +1,6 @@
 name = "python-pro"
 description = "Use when a task needs a Python-focused subagent for runtime behavior, packaging, typing, testing, or framework-adjacent implementation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/rails-expert.toml
+++ b/categories/02-language-specialists/rails-expert.toml
@@ -1,6 +1,6 @@
 name = "rails-expert"
 description = "Use when a task needs Ruby on Rails expertise for models, controllers, jobs, callbacks, or convention-driven application changes."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/react-specialist.toml
+++ b/categories/02-language-specialists/react-specialist.toml
@@ -1,6 +1,6 @@
 name = "react-specialist"
 description = "Use when a task needs a React-focused agent for component behavior, state flow, rendering bugs, or modern React patterns."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/rust-engineer.toml
+++ b/categories/02-language-specialists/rust-engineer.toml
@@ -1,6 +1,6 @@
 name = "rust-engineer"
 description = "Use when a task needs Rust expertise for ownership-heavy systems code, async runtime behavior, or performance-sensitive implementation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/spring-boot-engineer.toml
+++ b/categories/02-language-specialists/spring-boot-engineer.toml
@@ -1,6 +1,6 @@
 name = "spring-boot-engineer"
 description = "Use when a task needs Spring Boot expertise for service behavior, configuration, data access, or enterprise API implementation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/sql-pro.toml
+++ b/categories/02-language-specialists/sql-pro.toml
@@ -1,6 +1,6 @@
 name = "sql-pro"
 description = "Use when a task needs SQL query design, query review, schema-aware debugging, or database migration analysis."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/02-language-specialists/swift-expert.toml
+++ b/categories/02-language-specialists/swift-expert.toml
@@ -1,6 +1,6 @@
 name = "swift-expert"
 description = "Use when a task needs Swift expertise for iOS or macOS code, async flows, Apple platform APIs, or strongly typed application logic."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/typescript-pro.toml
+++ b/categories/02-language-specialists/typescript-pro.toml
@@ -1,6 +1,6 @@
 name = "typescript-pro"
 description = "Use when a task needs strong TypeScript help for types, interfaces, refactors, or compiler-driven fixes."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/vue-expert.toml
+++ b/categories/02-language-specialists/vue-expert.toml
@@ -1,6 +1,6 @@
 name = "vue-expert"
 description = "Use when a task needs Vue expertise for component behavior, Composition API patterns, routing, or state and rendering issues."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/azure-infra-engineer.toml
+++ b/categories/03-infrastructure/azure-infra-engineer.toml
@@ -1,6 +1,6 @@
 name = "azure-infra-engineer"
 description = "Use when a task needs Azure-specific infrastructure review or implementation across resources, networking, identity, or automation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/cloud-architect.toml
+++ b/categories/03-infrastructure/cloud-architect.toml
@@ -1,6 +1,6 @@
 name = "cloud-architect"
 description = "Use when a task needs cloud architecture review across compute, storage, networking, reliability, or multi-service design."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/database-administrator.toml
+++ b/categories/03-infrastructure/database-administrator.toml
@@ -1,6 +1,6 @@
 name = "database-administrator"
 description = "Use when a task needs operational database administration review for availability, backups, recovery, permissions, or runtime health."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/deployment-engineer.toml
+++ b/categories/03-infrastructure/deployment-engineer.toml
@@ -1,6 +1,6 @@
 name = "deployment-engineer"
 description = "Use when a task needs deployment workflow changes, release strategy updates, or rollout and rollback safety analysis."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/devops-engineer.toml
+++ b/categories/03-infrastructure/devops-engineer.toml
@@ -1,6 +1,6 @@
 name = "devops-engineer"
 description = "Use when a task needs CI, deployment pipeline, release automation, or environment configuration work."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/devops-incident-responder.toml
+++ b/categories/03-infrastructure/devops-incident-responder.toml
@@ -1,6 +1,6 @@
 name = "devops-incident-responder"
 description = "Use when a task needs rapid operational triage across CI, deployments, infrastructure automation, and service delivery failures."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/docker-expert.toml
+++ b/categories/03-infrastructure/docker-expert.toml
@@ -1,6 +1,6 @@
 name = "docker-expert"
 description = "Use when a task needs Dockerfile review, image optimization, multi-stage build fixes, or container runtime debugging."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/incident-responder.toml
+++ b/categories/03-infrastructure/incident-responder.toml
@@ -1,6 +1,6 @@
 name = "incident-responder"
 description = "Use when a task needs broad production incident triage, containment planning, or evidence-driven root cause analysis."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/kubernetes-specialist.toml
+++ b/categories/03-infrastructure/kubernetes-specialist.toml
@@ -1,6 +1,6 @@
 name = "kubernetes-specialist"
 description = "Use when a task needs Kubernetes manifest review, rollout safety analysis, or cluster workload debugging."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/network-engineer.toml
+++ b/categories/03-infrastructure/network-engineer.toml
@@ -1,6 +1,6 @@
 name = "network-engineer"
 description = "Use when a task needs network-path analysis, service connectivity debugging, load-balancer review, or infrastructure network design input."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/platform-engineer.toml
+++ b/categories/03-infrastructure/platform-engineer.toml
@@ -1,6 +1,6 @@
 name = "platform-engineer"
 description = "Use when a task needs internal platform, golden-path, or self-service infrastructure design for developers."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/security-engineer.toml
+++ b/categories/03-infrastructure/security-engineer.toml
@@ -1,6 +1,6 @@
 name = "security-engineer"
 description = "Use when a task needs infrastructure and platform security engineering across IAM, secrets, network controls, or hardening work."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/sre-engineer.toml
+++ b/categories/03-infrastructure/sre-engineer.toml
@@ -1,6 +1,6 @@
 name = "sre-engineer"
 description = "Use when a task needs reliability engineering work involving SLOs, alerting, error budgets, operational safety, or service resilience."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/terraform-engineer.toml
+++ b/categories/03-infrastructure/terraform-engineer.toml
@@ -1,6 +1,6 @@
 name = "terraform-engineer"
 description = "Use when a task needs Terraform module design, plan review, state-aware change analysis, or IaC refactoring."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/terragrunt-expert.toml
+++ b/categories/03-infrastructure/terragrunt-expert.toml
@@ -1,6 +1,6 @@
 name = "terragrunt-expert"
 description = "Use when a task needs Terragrunt-specific help for module orchestration, environment layering, dependency wiring, or DRY infrastructure structure."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/windows-infra-admin.toml
+++ b/categories/03-infrastructure/windows-infra-admin.toml
@@ -1,6 +1,6 @@
 name = "windows-infra-admin"
 description = "Use when a task needs Windows infrastructure administration across Active Directory, DNS, DHCP, GPO, or Windows automation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/accessibility-tester.toml
+++ b/categories/04-quality-security/accessibility-tester.toml
@@ -1,6 +1,6 @@
 name = "accessibility-tester"
 description = "Use when a task needs an accessibility audit of UI changes, interaction flows, or component behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/ad-security-reviewer.toml
+++ b/categories/04-quality-security/ad-security-reviewer.toml
@@ -1,6 +1,6 @@
 name = "ad-security-reviewer"
 description = "Use when a task needs Active Directory security review across identity boundaries, delegation, GPO exposure, or directory hardening."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/architect-reviewer.toml
+++ b/categories/04-quality-security/architect-reviewer.toml
@@ -1,6 +1,6 @@
 name = "architect-reviewer"
 description = "Use when a task needs architectural review for coupling, system boundaries, long-term maintainability, or design coherence."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/browser-debugger.toml
+++ b/categories/04-quality-security/browser-debugger.toml
@@ -1,6 +1,6 @@
 name = "browser-debugger"
 description = "Use when a task needs browser-based reproduction, UI evidence gathering, or client-side debugging through a browser MCP server."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/04-quality-security/chaos-engineer.toml
+++ b/categories/04-quality-security/chaos-engineer.toml
@@ -1,6 +1,6 @@
 name = "chaos-engineer"
 description = "Use when a task needs resilience analysis for dependency failure, degraded modes, recovery behavior, or controlled fault-injection planning."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/code-reviewer.toml
+++ b/categories/04-quality-security/code-reviewer.toml
@@ -1,6 +1,6 @@
 name = "code-reviewer"
 description = "Use when a task needs a broader code-health review covering maintainability, design clarity, and risky implementation choices in addition to correctness."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/compliance-auditor.toml
+++ b/categories/04-quality-security/compliance-auditor.toml
@@ -1,6 +1,6 @@
 name = "compliance-auditor"
 description = "Use when a task needs compliance-oriented review of controls, auditability, policy alignment, or evidence gaps in a regulated workflow."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/debugger.toml
+++ b/categories/04-quality-security/debugger.toml
@@ -1,6 +1,6 @@
 name = "debugger"
 description = "Use when a task needs deep bug isolation across code paths, stack traces, runtime behavior, or failing tests."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/error-detective.toml
+++ b/categories/04-quality-security/error-detective.toml
@@ -1,6 +1,6 @@
 name = "error-detective"
 description = "Use when a task needs log, exception, or stack-trace analysis to identify the most probable failure source quickly."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/penetration-tester.toml
+++ b/categories/04-quality-security/penetration-tester.toml
@@ -1,6 +1,6 @@
 name = "penetration-tester"
 description = "Use when a task needs adversarial review of an application path for exploitability, abuse cases, or practical attack surface analysis."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/performance-engineer.toml
+++ b/categories/04-quality-security/performance-engineer.toml
@@ -1,6 +1,6 @@
 name = "performance-engineer"
 description = "Use when a task needs performance investigation for slow requests, hot paths, rendering regressions, or scalability bottlenecks."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/powershell-security-hardening.toml
+++ b/categories/04-quality-security/powershell-security-hardening.toml
@@ -1,6 +1,6 @@
 name = "powershell-security-hardening"
 description = "Use when a task needs PowerShell-focused hardening across script safety, admin automation, execution controls, or Windows security posture."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/qa-expert.toml
+++ b/categories/04-quality-security/qa-expert.toml
@@ -1,6 +1,6 @@
 name = "qa-expert"
 description = "Use when a task needs test strategy, acceptance coverage planning, or risk-based QA guidance for a feature or release."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/reviewer.toml
+++ b/categories/04-quality-security/reviewer.toml
@@ -1,6 +1,6 @@
 name = "reviewer"
 description = "Use when a task needs PR-style review focused on correctness, security, behavior regressions, and missing tests."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/security-auditor.toml
+++ b/categories/04-quality-security/security-auditor.toml
@@ -1,6 +1,6 @@
 name = "security-auditor"
 description = "Use when a task needs focused security review of code, auth flows, secrets handling, input validation, or infrastructure configuration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/test-automator.toml
+++ b/categories/04-quality-security/test-automator.toml
@@ -1,6 +1,6 @@
 name = "test-automator"
 description = "Use when a task needs implementation of automated tests, test harness improvements, or targeted regression coverage."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/ai-engineer.toml
+++ b/categories/05-data-ai/ai-engineer.toml
@@ -1,6 +1,6 @@
 name = "ai-engineer"
 description = "Use when a task needs implementation or debugging of model-backed application features, agent flows, or evaluation hooks."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/data-analyst.toml
+++ b/categories/05-data-ai/data-analyst.toml
@@ -1,6 +1,6 @@
 name = "data-analyst"
 description = "Use when a task needs data interpretation, metric breakdown, trend explanation, or decision support from existing analytics outputs."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/data-engineer.toml
+++ b/categories/05-data-ai/data-engineer.toml
@@ -1,6 +1,6 @@
 name = "data-engineer"
 description = "Use when a task needs ETL, ingestion, transformation, warehouse, or data-pipeline implementation and debugging."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/data-scientist.toml
+++ b/categories/05-data-ai/data-scientist.toml
@@ -1,6 +1,6 @@
 name = "data-scientist"
 description = "Use when a task needs statistical reasoning, experiment interpretation, feature analysis, or model-oriented data exploration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/database-optimizer.toml
+++ b/categories/05-data-ai/database-optimizer.toml
@@ -1,6 +1,6 @@
 name = "database-optimizer"
 description = "Use when a task needs database performance analysis for query plans, schema design, indexing, or data access patterns."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/llm-architect.toml
+++ b/categories/05-data-ai/llm-architect.toml
@@ -1,6 +1,6 @@
 name = "llm-architect"
 description = "Use when a task needs architecture review for prompts, tool use, retrieval, evaluation, or multi-step LLM workflows."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/machine-learning-engineer.toml
+++ b/categories/05-data-ai/machine-learning-engineer.toml
@@ -1,6 +1,6 @@
 name = "machine-learning-engineer"
 description = "Use when a task needs ML system implementation work across training pipelines, feature flow, model serving, or inference integration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/ml-engineer.toml
+++ b/categories/05-data-ai/ml-engineer.toml
@@ -1,6 +1,6 @@
 name = "ml-engineer"
 description = "Use when a task needs practical machine learning implementation across feature engineering, inference wiring, and model-backed application logic."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/mlops-engineer.toml
+++ b/categories/05-data-ai/mlops-engineer.toml
@@ -1,6 +1,6 @@
 name = "mlops-engineer"
 description = "Use when a task needs model deployment, registry, pipeline, monitoring, or environment orchestration for machine learning systems."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/nlp-engineer.toml
+++ b/categories/05-data-ai/nlp-engineer.toml
@@ -1,6 +1,6 @@
 name = "nlp-engineer"
 description = "Use when a task needs NLP-specific implementation or analysis involving text processing, embeddings, ranking, or language-model-adjacent pipelines."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/postgres-pro.toml
+++ b/categories/05-data-ai/postgres-pro.toml
@@ -1,6 +1,6 @@
 name = "postgres-pro"
 description = "Use when a task needs PostgreSQL-specific expertise for schema design, performance behavior, locking, or operational database features."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/prompt-engineer.toml
+++ b/categories/05-data-ai/prompt-engineer.toml
@@ -1,6 +1,6 @@
 name = "prompt-engineer"
 description = "Use when a task needs prompt revision, instruction design, eval-oriented prompt comparison, or prompt-output contract tightening."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/build-engineer.toml
+++ b/categories/06-developer-experience/build-engineer.toml
@@ -1,6 +1,6 @@
 name = "build-engineer"
 description = "Use when a task needs build-graph debugging, bundling fixes, compiler pipeline work, or CI build stabilization."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/cli-developer.toml
+++ b/categories/06-developer-experience/cli-developer.toml
@@ -1,6 +1,6 @@
 name = "cli-developer"
 description = "Use when a task needs a command-line interface feature, UX review, argument parsing change, or shell-facing workflow improvement."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/dependency-manager.toml
+++ b/categories/06-developer-experience/dependency-manager.toml
@@ -1,6 +1,6 @@
 name = "dependency-manager"
 description = "Use when a task needs dependency upgrades, package graph analysis, version-policy cleanup, or third-party library risk assessment."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/documentation-engineer.toml
+++ b/categories/06-developer-experience/documentation-engineer.toml
@@ -1,6 +1,6 @@
 name = "documentation-engineer"
 description = "Use when a task needs technical documentation that must stay faithful to current code, tooling, and operator workflows."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/dx-optimizer.toml
+++ b/categories/06-developer-experience/dx-optimizer.toml
@@ -1,6 +1,6 @@
 name = "dx-optimizer"
 description = "Use when a task needs developer-experience improvements in setup time, local workflows, feedback loops, or day-to-day tooling friction."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/git-workflow-manager.toml
+++ b/categories/06-developer-experience/git-workflow-manager.toml
@@ -1,6 +1,6 @@
 name = "git-workflow-manager"
 description = "Use when a task needs help with branching strategy, merge flow, release branching, or repository collaboration conventions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/legacy-modernizer.toml
+++ b/categories/06-developer-experience/legacy-modernizer.toml
@@ -1,6 +1,6 @@
 name = "legacy-modernizer"
 description = "Use when a task needs a modernization path for older code, frameworks, or architecture without losing behavioral safety."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/mcp-developer.toml
+++ b/categories/06-developer-experience/mcp-developer.toml
@@ -1,6 +1,6 @@
 name = "mcp-developer"
 description = "Use when a task needs work on MCP servers, MCP clients, tool wiring, or protocol-aware integrations."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/powershell-module-architect.toml
+++ b/categories/06-developer-experience/powershell-module-architect.toml
@@ -1,6 +1,6 @@
 name = "powershell-module-architect"
 description = "Use when a task needs PowerShell module structure, command design, packaging, or profile architecture work."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/powershell-ui-architect.toml
+++ b/categories/06-developer-experience/powershell-ui-architect.toml
@@ -1,6 +1,6 @@
 name = "powershell-ui-architect"
 description = "Use when a task needs PowerShell-based UI work for terminals, forms, WPF, or admin-oriented interactive tooling."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/refactoring-specialist.toml
+++ b/categories/06-developer-experience/refactoring-specialist.toml
@@ -1,6 +1,6 @@
 name = "refactoring-specialist"
 description = "Use when a task needs a low-risk structural refactor that preserves behavior while improving readability, modularity, or maintainability."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/slack-expert.toml
+++ b/categories/06-developer-experience/slack-expert.toml
@@ -1,6 +1,6 @@
 name = "slack-expert"
 description = "Use when a task needs Slack platform work involving bots, interactivity, events, workflows, or Slack-specific integration behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/tooling-engineer.toml
+++ b/categories/06-developer-experience/tooling-engineer.toml
@@ -1,6 +1,6 @@
 name = "tooling-engineer"
 description = "Use when a task needs internal developer tooling, scripts, automation glue, or workflow support utilities."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/api-documenter.toml
+++ b/categories/07-specialized-domains/api-documenter.toml
@@ -1,6 +1,6 @@
 name = "api-documenter"
 description = "Use when a task needs consumer-facing API documentation generated from the real implementation, schema, and examples."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/blockchain-developer.toml
+++ b/categories/07-specialized-domains/blockchain-developer.toml
@@ -1,6 +1,6 @@
 name = "blockchain-developer"
 description = "Use when a task needs blockchain or Web3 implementation and review across smart-contract integration, wallet flows, or transaction lifecycle handling."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/embedded-systems.toml
+++ b/categories/07-specialized-domains/embedded-systems.toml
@@ -1,6 +1,6 @@
 name = "embedded-systems"
 description = "Use when a task needs embedded or hardware-adjacent work involving device constraints, firmware boundaries, timing, or low-level integration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/fintech-engineer.toml
+++ b/categories/07-specialized-domains/fintech-engineer.toml
@@ -1,6 +1,6 @@
 name = "fintech-engineer"
 description = "Use when a task needs financial systems engineering across ledgers, reconciliation, transfers, settlement, or compliance-sensitive transactional flows."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/game-developer.toml
+++ b/categories/07-specialized-domains/game-developer.toml
@@ -1,6 +1,6 @@
 name = "game-developer"
 description = "Use when a task needs game-specific implementation or debugging involving gameplay systems, rendering loops, asset flow, or player-state behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/iot-engineer.toml
+++ b/categories/07-specialized-domains/iot-engineer.toml
@@ -1,6 +1,6 @@
 name = "iot-engineer"
 description = "Use when a task needs IoT system work involving devices, telemetry, edge communication, or cloud-device coordination."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/m365-admin.toml
+++ b/categories/07-specialized-domains/m365-admin.toml
@@ -1,6 +1,6 @@
 name = "m365-admin"
 description = "Use when a task needs Microsoft 365 administration help across Exchange Online, Teams, SharePoint, identity, or tenant-level automation."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/mobile-app-developer.toml
+++ b/categories/07-specialized-domains/mobile-app-developer.toml
@@ -1,6 +1,6 @@
 name = "mobile-app-developer"
 description = "Use when a task needs app-level mobile product work across screens, state, API integration, and release-sensitive mobile behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/payment-integration.toml
+++ b/categories/07-specialized-domains/payment-integration.toml
@@ -1,6 +1,6 @@
 name = "payment-integration"
 description = "Use when a task needs payment-flow review or implementation for checkout, idempotency, webhooks, retries, or settlement state handling."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/quant-analyst.toml
+++ b/categories/07-specialized-domains/quant-analyst.toml
@@ -1,6 +1,6 @@
 name = "quant-analyst"
 description = "Use when a task needs quantitative analysis of models, strategies, simulations, or numeric decision logic."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/risk-manager.toml
+++ b/categories/07-specialized-domains/risk-manager.toml
@@ -1,6 +1,6 @@
 name = "risk-manager"
 description = "Use when a task needs explicit risk analysis for product, operational, financial, or architectural decisions."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/seo-specialist.toml
+++ b/categories/07-specialized-domains/seo-specialist.toml
@@ -1,6 +1,6 @@
 name = "seo-specialist"
 description = "Use when a task needs search-focused technical review across crawlability, metadata, rendering, information architecture, or content discoverability."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/business-analyst.toml
+++ b/categories/08-business-product/business-analyst.toml
@@ -1,6 +1,6 @@
 name = "business-analyst"
 description = "Use when a task needs requirements clarified, scope normalized, or acceptance criteria extracted from messy inputs before engineering work starts."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/content-marketer.toml
+++ b/categories/08-business-product/content-marketer.toml
@@ -1,6 +1,6 @@
 name = "content-marketer"
 description = "Use when a task needs product-adjacent content strategy or messaging that still has to stay grounded in real technical capabilities."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/customer-success-manager.toml
+++ b/categories/08-business-product/customer-success-manager.toml
@@ -1,6 +1,6 @@
 name = "customer-success-manager"
 description = "Use when a task needs support-pattern synthesis, adoption risk analysis, or customer-facing operational guidance from engineering context."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/legal-advisor.toml
+++ b/categories/08-business-product/legal-advisor.toml
@@ -1,6 +1,6 @@
 name = "legal-advisor"
 description = "Use when a task needs legal-risk spotting in product or engineering behavior, especially around terms, data handling, or externally visible commitments."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/product-manager.toml
+++ b/categories/08-business-product/product-manager.toml
@@ -1,6 +1,6 @@
 name = "product-manager"
 description = "Use when a task needs product framing, prioritization, or feature-shaping based on engineering reality and user impact."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/project-manager.toml
+++ b/categories/08-business-product/project-manager.toml
@@ -1,6 +1,6 @@
 name = "project-manager"
 description = "Use when a task needs dependency mapping, milestone planning, sequencing, or delivery-risk coordination across multiple workstreams."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/sales-engineer.toml
+++ b/categories/08-business-product/sales-engineer.toml
@@ -1,6 +1,6 @@
 name = "sales-engineer"
 description = "Use when a task needs technically accurate solution positioning, customer-question handling, or implementation tradeoff explanation for pre-sales contexts."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/scrum-master.toml
+++ b/categories/08-business-product/scrum-master.toml
@@ -1,6 +1,6 @@
 name = "scrum-master"
 description = "Use when a task needs process facilitation, iteration planning, or workflow friction analysis for an engineering team."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/technical-writer.toml
+++ b/categories/08-business-product/technical-writer.toml
@@ -1,6 +1,6 @@
 name = "technical-writer"
 description = "Use when a task needs release notes, migration notes, onboarding material, or developer-facing prose derived from real code changes."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/08-business-product/ux-researcher.toml
+++ b/categories/08-business-product/ux-researcher.toml
@@ -1,6 +1,6 @@
 name = "ux-researcher"
 description = "Use when a task needs UI feedback synthesized into actionable product and implementation guidance."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/wordpress-master.toml
+++ b/categories/08-business-product/wordpress-master.toml
@@ -1,6 +1,6 @@
 name = "wordpress-master"
 description = "Use when a task needs WordPress-specific implementation or debugging across themes, plugins, content architecture, or operational site behavior."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/09-meta-orchestration/agent-installer.toml
+++ b/categories/09-meta-orchestration/agent-installer.toml
@@ -1,6 +1,6 @@
 name = "agent-installer"
 description = "Use when a task needs help selecting, copying, or organizing custom agent files from this repository into Codex agent directories."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/agent-organizer.toml
+++ b/categories/09-meta-orchestration/agent-organizer.toml
@@ -1,6 +1,6 @@
 name = "agent-organizer"
 description = "Use when the parent agent needs help choosing subagents and dividing a larger task into clean delegated threads."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/context-manager.toml
+++ b/categories/09-meta-orchestration/context-manager.toml
@@ -1,6 +1,6 @@
 name = "context-manager"
 description = "Use when a task needs a compact project context summary that other subagents can rely on before deeper work begins."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/error-coordinator.toml
+++ b/categories/09-meta-orchestration/error-coordinator.toml
@@ -1,6 +1,6 @@
 name = "error-coordinator"
 description = "Use when multiple errors or symptoms need to be grouped, prioritized, and assigned to the right debugging or review agents."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/it-ops-orchestrator.toml
+++ b/categories/09-meta-orchestration/it-ops-orchestrator.toml
@@ -1,6 +1,6 @@
 name = "it-ops-orchestrator"
 description = "Use when a task needs coordinated operational planning across infrastructure, incident response, identity, endpoint, and admin workflows."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/knowledge-synthesizer.toml
+++ b/categories/09-meta-orchestration/knowledge-synthesizer.toml
@@ -1,6 +1,6 @@
 name = "knowledge-synthesizer"
 description = "Use when multiple agents have returned findings and the parent agent needs a distilled, non-redundant synthesis."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/multi-agent-coordinator.toml
+++ b/categories/09-meta-orchestration/multi-agent-coordinator.toml
@@ -1,6 +1,6 @@
 name = "multi-agent-coordinator"
 description = "Use when a task needs a concrete multi-agent plan with clear role separation, dependencies, and result integration."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/performance-monitor.toml
+++ b/categories/09-meta-orchestration/performance-monitor.toml
@@ -1,6 +1,6 @@
 name = "performance-monitor"
 description = "Use when a task needs ongoing performance-signal interpretation across build, runtime, or operational metrics before deeper optimization starts."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/task-distributor.toml
+++ b/categories/09-meta-orchestration/task-distributor.toml
@@ -1,6 +1,6 @@
 name = "task-distributor"
 description = "Use when a broad task needs to be broken into concrete sub-tasks with clear boundaries for multiple agents or contributors."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/workflow-orchestrator.toml
+++ b/categories/09-meta-orchestration/workflow-orchestrator.toml
@@ -1,6 +1,6 @@
 name = "workflow-orchestrator"
 description = "Use when the parent agent needs an explicit Codex subagent workflow for a complex task with multiple stages."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/competitive-analyst.toml
+++ b/categories/10-research-analysis/competitive-analyst.toml
@@ -1,6 +1,6 @@
 name = "competitive-analyst"
 description = "Use when a task needs a grounded comparison of tools, products, libraries, or implementation options."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/data-researcher.toml
+++ b/categories/10-research-analysis/data-researcher.toml
@@ -1,6 +1,6 @@
 name = "data-researcher"
 description = "Use when a task needs source gathering and synthesis around datasets, metrics, data pipelines, or evidence-backed quantitative questions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/docs-researcher.toml
+++ b/categories/10-research-analysis/docs-researcher.toml
@@ -1,6 +1,6 @@
 name = "docs-researcher"
 description = "Use when a task needs documentation-backed verification of APIs, version-specific behavior, or framework options."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/market-researcher.toml
+++ b/categories/10-research-analysis/market-researcher.toml
@@ -1,6 +1,6 @@
 name = "market-researcher"
 description = "Use when a task needs market landscape, positioning, or demand-side research tied to a technical product or category."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/research-analyst.toml
+++ b/categories/10-research-analysis/research-analyst.toml
@@ -1,6 +1,6 @@
 name = "research-analyst"
 description = "Use when a task needs a structured investigation of a technical topic, implementation approach, or design question."
-model = "gpt-5.4"
+model = "gpt-5.5"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/search-specialist.toml
+++ b/categories/10-research-analysis/search-specialist.toml
@@ -1,6 +1,6 @@
 name = "search-specialist"
 description = "Use when a task needs fast, high-signal searching of the codebase or external sources before deeper analysis begins."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/trend-analyst.toml
+++ b/categories/10-research-analysis/trend-analyst.toml
@@ -1,6 +1,6 @@
 name = "trend-analyst"
 description = "Use when a task needs trend synthesis across technology shifts, adoption patterns, or emerging implementation directions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.4-mini"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """


### PR DESCRIPTION
I updated each subagent GPT model by using the latest gpt-5.5 with xhigh reasoning. Check the PR message from him.

## Summary

Refreshes Codex subagent model routing to align with the current recommended model tiers.

## Changes

- Updates deep/complex subagents from `gpt-5.4` to `gpt-5.5`
- Updates lightweight/fast subagents from `gpt-5.3-codex-spark` to `gpt-5.4-mini`
- Preserves all existing `model_reasoning_effort` values
  - `high`: 107 agents
  - `medium`: 29 agents
- Updates the README example and Smart Model Routing table
- Updates CONTRIBUTING model guidance to match the new model routing

## Why `gpt-5.4-mini`

`gpt-5.4-mini` is the current recommended faster, lower-cost Codex model for lighter coding tasks and subagents. This keeps the intended fast/efficient routing for lightweight agents while moving away from the older `gpt-5.3-codex-spark` assignment.

This update simplifies the model matrix:

- `gpt-5.5` for deep reasoning and complex engineering tasks
- `gpt-5.4-mini` for fast scanning, synthesis, documentation, and lightweight support tasks

Sources:

- Codex model guidance: https://developers.openai.com/codex/models
- Custom subagent config fields: https://developers.openai.com/codex/subagents

## Verification

- Confirmed model distribution:
  - `gpt-5.5`: 107 TOML files
  - `gpt-5.4-mini`: 29 TOML files
- Confirmed reasoning effort distribution remained unchanged:
  - `high`: 107 TOML files
  - `medium`: 29 TOML files
- Confirmed no remaining old model assignments in `categories/**/*.toml`
- Parsed all 136 TOML files successfully with Python `tomllib`