### PR TITLE
Add Emdash Skills -- autonomous product-building OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ DevOps, cloud, and deployment specialists.
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.toml) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.toml) - Multi-agent coordinator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.toml) - Context optimization expert
+- [**emdash-skills**](https://github.com/megabytespace/claude-skills) - 14-category autonomous product-building OS with 94 reference docs, 18 agents, and Codex-native skills support
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.toml) - Error handling and recovery specialist
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.toml) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.toml) - Knowledge aggregation expert

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -7,6 +7,7 @@ Included agents:
 - `agent-installer` - Help pick and install agents from this repository.
 - `agent-organizer` - Pick the right subagents and divide the work cleanly.
 - `context-manager` - Produce a compact project context packet for other agents.
+- `emdash-skills` - 14-category autonomous product-building OS with 94 reference docs and 18 agents. [External repo](https://github.com/megabytespace/claude-skills)
 - `error-coordinator` - Group and prioritize multiple error threads.
 - `it-ops-orchestrator` - Coordinate cross-domain IT and operations workflows.
 - `knowledge-synthesizer` - Merge findings from multiple agents into a usable summary.


### PR DESCRIPTION
Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the **09. Meta & Orchestration** category as an external repo link.

**What it is:** A 14-category autonomous product-building OS for AI coding tools. 94 reference docs, 18 agents, Codex-native skills support. Covers the full product lifecycle from architecture through deploy and verification.

**Files changed:**
- `README.md` — Added `emdash-skills` entry in 09. Meta & Orchestration (alphabetical, between `context-manager` and `error-coordinator`), matching the external link format used by `pied-piper`.
- `categories/09-meta-orchestration/README.md` — Added matching entry to the category README.

No `.toml` file included since this is an external multi-agent orchestration framework (same pattern as `pied-piper`).