### PR TITLE
Add claude-skills (18 subagents) to Meta & Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ DevOps, cloud, and deployment specialists.
 
 - [**agent-installer**](categories/09-meta-orchestration/agent-installer.toml) - Browse and install agents from this repository via GitHub
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.toml) - Multi-agent coordinator
+- [**claude-skills**](https://github.com/heymegabyte/claude-skills) - 18 specialized subagents (architect, test-writer, deploy-verifier, security-reviewer, visual-qa, performance-profiler, accessibility-auditor, content-writer, completeness-checker, dependency-auditor, migration-agent, incident-responder, computer-use-operator, meta-orchestrator, seo-auditor, cost-estimator, changelog-generator, code-simplifier) that orchestrate in parallel — Codex-native via `.codex/agents/` and `.agents/skills/`. Cross-tool config also drops into Claude Code, Cursor, Copilot, Gemini CLI
 - [**context-manager**](categories/09-meta-orchestration/context-manager.toml) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.toml) - Error handling and recovery specialist
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.toml) - IT operations workflow orchestration specialist


### PR DESCRIPTION
Adds **[claude-skills](https://github.com/heymegabyte/claude-skills)** to *09. Meta & Orchestration*, alphabetically between `agent-organizer` and `context-manager`.

### What it is
18 specialized subagents that orchestrate in parallel from a single config:
- **Architecture & code:** architect, code-simplifier, migration-agent, dependency-auditor
- **Quality:** test-writer, completeness-checker, security-reviewer, accessibility-auditor, visual-qa, performance-profiler
- **Content & docs:** content-writer, seo-auditor, changelog-generator
- **Ops:** deploy-verifier, incident-responder, cost-estimator
- **Meta:** meta-orchestrator, computer-use-operator

### Codex-native
Drops directly into `~/.codex/agents/` (global) or `.codex/agents/` (project) — same `.toml` format documented in this list. Also ships an `.agents/skills/` bundle for Codex skill autoload.

### Cross-tool
Same config compiles to Claude Code, Cursor, Copilot, Gemini CLI, Windsurf, opencode, Cline, Aider — write once, run everywhere.

### Checklist
- [x] Alphabetical placement preserved (agent-organizer → claude-skills → context-manager)
- [x] Correct category (Meta & Orchestration — multi-agent set)
- [x] One repo per PR