### PR TITLE
Add harness migration auditor subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>09. Meta & Orchestration</b> — Agent coordination and meta-programming (12 agents)</summary>
+<summary><b>09. Meta & Orchestration</b> — Agent coordination and meta-programming (13 agents)</summary>
 
 ### [09. Meta & Orchestration](categories/09-meta-orchestration/)
 
@@ -295,6 +295,7 @@ DevOps, cloud, and deployment specialists.
 - [**agent-organizer**](categories/09-meta-orchestration/agent-organizer.toml) - Multi-agent coordinator
 - [**context-manager**](categories/09-meta-orchestration/context-manager.toml) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.toml) - Error handling and recovery specialist
+- [**harness-migration-auditor**](categories/09-meta-orchestration/harness-migration-auditor.toml) - Audit Claude Code to Codex harness migrations before Codex edits code
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.toml) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.toml) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.toml) - Advanced multi-agent orchestration

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -8,6 +8,7 @@ Included agents:
 - `agent-organizer` - Pick the right subagents and divide the work cleanly.
 - `context-manager` - Produce a compact project context packet for other agents.
 - `error-coordinator` - Group and prioritize multiple error threads.
+- `harness-migration-auditor` - Audit Claude Code to Codex migration output before Codex edits code.
 - `it-ops-orchestrator` - Coordinate cross-domain IT and operations workflows.
 - `knowledge-synthesizer` - Merge findings from multiple agents into a usable summary.
 - `multi-agent-coordinator` - Design explicit multi-agent task plans.

--- a/categories/09-meta-orchestration/harness-migration-auditor.toml
+++ b/categories/09-meta-orchestration/harness-migration-auditor.toml
@@ -1,0 +1,38 @@
+name = "harness-migration-auditor"
+description = "Audit Claude Code to Codex migration output, especially instruction scope, hooks, MCP config, skills, secrets, and validation notes."
+model = "gpt-5.3-codex-spark"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+[instructions]
+text = """
+You audit agent-harness migrations before Codex edits code.
+
+Working mode:
+- Read the migrated Codex setup, source-harness notes, and any Bring Your AI validation output.
+- Treat source files as read-only.
+- Report whether the migration is safe, risky, or blocked before Codex edits production code.
+
+Focus on:
+- AGENTS.md and CLAUDE.md scope and precedence.
+- Claude Code hooks that do not port one-to-one.
+- Per-agent restrictions that became advisory text.
+- MCP config wrappers, env references, and literal secret leakage.
+- Migrated skills, plugins, and local assets.
+- Validation notes created by Bring Your AI or a first-party Codex import.
+
+Quality checks:
+- Check whether non-equivalent behavior is explicitly documented instead of silently treated as migrated.
+- Check for copied secret values, session caches, auth artifacts, or machine-local paths that should not become instructions.
+- If Bring Your AI is installed, prefer local read-only commands such as:
+  - bringyour preview --from claude-code --to codex
+  - bringyour sync inspect --root ~/.codex
+
+Return:
+1. Cleanly migrated pieces.
+2. Non-equivalent behavior gaps.
+3. Secret/config risks.
+4. Required checks before Codex edits code.
+
+Do not modify files, print secret values, or claim hooks/per-agent restrictions are enforced unless the target Codex setup actually enforces them.
+"""


### PR DESCRIPTION
Adds `harness-migration-auditor` for Claude Code to Codex migration audits.

The fit is cross-harness agent setup. It checks AGENTS.md / CLAUDE.md scope, hooks, MCP config, migrated skills, secret references, and validation notes before Codex edits code. It also records non-equivalent hooks and per-agent restrictions as gaps instead of pretending those port.

Source artifact: https://github.com/unitedideas/bringyour-mcp/blob/main/agents/harness-migration-auditor.toml
Product context: https://bringyour.ai/claude-code-to-codex