### PR TITLE
Fix Chrome DevTools MCP startup

### DIFF
--- a/categories/04-quality-security/browser-debugger.toml
+++ b/categories/04-quality-security/browser-debugger.toml
@@ -41,5 +41,6 @@ Do not broaden into unrelated frontend refactors unless explicitly requested by 
 """
 
 [mcp_servers.chrome_devtools]
-url = "http://localhost:3000/mcp"
-startup_timeout_sec = 20
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest", "--headless", "--isolated", "--no-usage-statistics"]
+startup_timeout_sec = 60


### PR DESCRIPTION
## Summary
- switch the browser-debugger Chrome DevTools MCP server from an unavailable localhost HTTP endpoint to the stdio npx launcher
- run the MCP server headless and isolated with usage statistics disabled
- increase startup timeout to 60 seconds for npm package startup

## Validation
- parsed categories/04-quality-security/browser-debugger.toml with Python tomllib
- locally smoke-tested MCP initialize before commit: serverInfo.name=chrome_devtools, version=0.25.0, protocolVersion=2025-06-18