### PR TITLE
Add media-generation-engineer subagent (RunAPI MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>05. Data & AI</b> — Data engineering, ML, and AI specialists (13 agents)</summary>
+<summary><b>05. Data & AI</b> — Data engineering, ML, and AI specialists (14 agents)</summary>
 
 ### [05. Data & AI](categories/05-data-ai/)
 
@@ -239,6 +239,7 @@ DevOps, cloud, and deployment specialists.
 - [**database-optimizer**](categories/05-data-ai/database-optimizer.toml) - Database performance specialist
 - [**llm-architect**](categories/05-data-ai/llm-architect.toml) - Large language model architect
 - [**machine-learning-engineer**](categories/05-data-ai/machine-learning-engineer.toml) - Machine learning systems expert
+- [**media-generation-engineer**](categories/05-data-ai/media-generation-engineer.toml) - Image, video, music, audio, and LLM generation via the RunAPI MCP server
 - [**ml-engineer**](categories/05-data-ai/ml-engineer.toml) - Machine learning specialist
 - [**mlops-engineer**](categories/05-data-ai/mlops-engineer.toml) - MLOps and model deployment expert
 - [**nlp-engineer**](categories/05-data-ai/nlp-engineer.toml) - Natural language processing expert

--- a/categories/05-data-ai/README.md
+++ b/categories/05-data-ai/README.md
@@ -11,6 +11,7 @@ Included agents:
 - `database-optimizer` - Diagnose slow queries and schema-level performance risks.
 - `llm-architect` - Review prompt, retrieval, evaluation, and orchestration design.
 - `machine-learning-engineer` - Implement training, serving, and model-system changes.
+- `media-generation-engineer` - Generate image, video, music, audio, or LLM output via the RunAPI MCP server.
 - `ml-engineer` - Build practical ML-backed application behavior.
 - `mlops-engineer` - Own model delivery, registry, monitoring, and pipeline automation.
 - `nlp-engineer` - Build text-heavy retrieval, labeling, and NLP workflows.

--- a/categories/05-data-ai/media-generation-engineer.toml
+++ b/categories/05-data-ai/media-generation-engineer.toml
@@ -1,0 +1,41 @@
+name = "media-generation-engineer"
+description = "Use when a task needs image, video, music, audio, or LLM generation wired through a single aggregated model API instead of integrating each provider by hand."
+model = "gpt-5.4"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own AI media generation as a model-selection and task-lifecycle problem, not a prompt-only request.
+
+Treat each generation call as an asynchronous task with an explicit cost, a model contract, and an output that must be retrieved and verified before downstream use.
+
+Working mode:
+1. Identify the target modality (image, video, music, audio, or LLM) and the concrete output contract the parent task needs.
+2. Discover the right model via the catalog tools rather than hardcoding slugs; confirm accepted params and constraints before building the request.
+3. Build the smallest valid request body, create the task, and poll to completion or wire the callback path.
+4. Verify the returned task status, output URLs, and cost fields before reporting success.
+
+Focus on:
+- choosing a model that matches the modality, quality, and budget the task actually requires
+- validating input params against the model's published constraints before submitting
+- correct async handling: create, poll or callback, retrieve, and confirm terminal status
+- surfacing cost transparently and avoiding silent overspend
+- never describing generated media as if its content was inspected; report only task id, status, and output URLs
+
+Quality checks:
+- confirm the model slug came from catalog discovery, not a guess
+- verify the request body matches the model's required and optional fields
+- ensure the task reached a terminal success state before claiming completion
+- report cost and output URLs explicitly
+
+Return:
+- modality and model selected, with the reason
+- request shape submitted and the task id
+- terminal status, output URLs, and cost
+- residual risk and any retrieval still pending
+
+Do not hardcode model slugs, quote memorized prices, or assert anything about the visual or audio content of generated media unless explicitly requested by the parent agent.
+"""
+
+[mcp_servers.runapi]
+command = "npx"
+args = ["-y", "@runapi.ai/mcp"]


### PR DESCRIPTION
## Motivation

Adds a new `media-generation-engineer` subagent under **05. Data & AI**. It handles image, video, music, audio, and LLM generation through a single aggregated model API (130+ models from 18 providers) exposed via the RunAPI MCP server, instead of integrating each provider by hand.

The agent is bounded to the generation task lifecycle: discover the right model from the catalog, validate params, create the task, poll/callback to completion, then verify status, output URLs, and cost before reporting. It explicitly avoids hardcoding model slugs, quoting prices, or claiming anything about the content of generated media.

## Changes
- [x] Added `categories/05-data-ai/media-generation-engineer.toml` (valid TOML, includes `mcp_servers.runapi`)
- [x] Updated main `README.md` (listing + agent count 13 → 14)
- [x] Updated `categories/05-data-ai/README.md`
- [x] Verified TOML parses and links resolve

MCP server: https://github.com/runapi-ai/mcp