### PR TITLE
Update Codex models and add graph-engineering agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ documentation research. Existing agent files are preserved unless you pass
 
 The preset also includes a graph-engineering team for dependency-aware planning,
 parallel execution, context curation, routing, and independent verification.
+The graph roles act as a control plane and can route work to any other installed
+specialist agent; they are not a closed five-agent team.
 
 Useful alternatives:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 171+ Codex subagents across 13 categories.</strong>
+    <strong>The awesome collection of 177+ Codex subagents across 13 categories.</strong>
     <br />
     <br />
 </div>
@@ -15,7 +15,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-171-blue?style=classic)
+![Subagent Count](https://img.shields.io/badge/subagents-177-blue?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -34,10 +34,44 @@ Use Codex custom agent directories exactly as documented:
 - `~/.codex/agents/` for global agents (available in all projects)
 - `.codex/agents/` for project-specific agents (higher precedence in that repo)
 
-1. Clone this repository.
-2. Copy the `.toml` agent files you want into one of the directories above.
-3. Restart or refresh your Codex session if needed.
-4. Delegate explicitly in prompts (Codex does not auto-spawn custom subagents).
+### Recommended: everyday development preset
+
+Install a focused set of 15 agents globally:
+
+```bash
+./scripts/install.sh
+```
+
+This preset covers codebase mapping, backend and frontend implementation,
+debugging, review, tests, refactoring, dependencies, Git workflows, and
+documentation research. Existing agent files are preserved unless you pass
+`--force`.
+
+The preset also includes a graph-engineering team for dependency-aware planning,
+parallel execution, context curation, routing, and independent verification.
+
+Useful alternatives:
+
+```bash
+# Preview without writing
+./scripts/install.sh --dry-run
+
+# Install the everyday preset only for the current project
+./scripts/install.sh --scope project
+
+# Install the complete collection globally
+./scripts/install.sh --preset all
+```
+
+Restart or refresh your Codex session after installation. Ask Codex explicitly
+to delegate work when you want subagents, for example:
+
+```text
+Have code-mapper trace the affected path, debugger identify the failure,
+and reviewer check the resulting patch. Wait for all agents and summarize.
+```
+
+### Manual installation
 
 Examples:
 ```bash
@@ -92,12 +126,10 @@ Each subagent uses a Codex-native `.toml` format:
 ```toml
 name = "subagent-name"
 description = "When this agent should be invoked"
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
-
-[instructions]
-text = """
+developer_instructions = """
 You are a [role description and expertise areas]...
 
 [Agent-specific checklists, patterns, and guidelines]...
@@ -110,14 +142,26 @@ Each subagent includes a `model` field that automatically routes it to the right
 
 | Model | When It's Used | Examples |
 |-------|----------------|----------|
-| `gpt-5.4` | Deep reasoning -- architecture reviews, security audits, financial logic | `security-auditor`, `architect-reviewer`, `fintech-engineer` |
-| `gpt-5.3-codex-spark` | Fast scanning, synthesis, and lighter research tasks | `search-specialist`, `docs-researcher`, `agent-installer` |
+| `gpt-5.6-sol` | Frontier coding and deep reasoning -- implementation, architecture, security, and complex debugging | `backend-developer`, `security-auditor`, `architect-reviewer` |
+| `gpt-5.6-terra` | Balanced everyday work -- fast scanning, tests, synthesis, docs, and repository operations | `code-mapper`, `test-automator`, `docs-researcher` |
+
+The routing intentionally preserves two roles instead of pinning every agent to
+the most expensive model. Use `gpt-5.6-sol` where deeper reasoning and
+follow-through matter, and `gpt-5.6-terra` for lighter parallel work.
 
 ### Sandbox Mode Philosophy
 
 Each subagent's `sandbox_mode` field controls filesystem access:
 - **Read-only agents** (reviewers, auditors): `sandbox_mode = "read-only"` - analyze without modifying
 - **Workspace-write agents** (developers, engineers): `sandbox_mode = "workspace-write"` - create and modify files
+
+## Validation
+
+Validate every agent file with Python 3.11 or newer:
+
+```bash
+python3 scripts/validate_agents.py
+```
 
 
 
@@ -318,7 +362,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>09. Meta & Orchestration</b> — Agent coordination and meta-programming (12 agents)</summary>
+<summary><b>09. Meta & Orchestration</b> — Agent coordination and meta-programming (17 agents)</summary>
 
 ### [09. Meta & Orchestration](categories/09-meta-orchestration/)
 
@@ -327,6 +371,11 @@ DevOps, cloud, and deployment specialists.
 - [**codebase-orchestrator**](categories/09-meta-orchestration/codebase-orchestrator.toml) - Repo-wide refactor governance with approval gates
 - [**context-manager**](categories/09-meta-orchestration/context-manager.toml) - Context optimization expert
 - [**error-coordinator**](categories/09-meta-orchestration/error-coordinator.toml) - Error handling and recovery specialist
+- [**graph-context-curator**](categories/09-meta-orchestration/graph-context-curator.toml) - Shared-state compression between graph waves
+- [**graph-planner**](categories/09-meta-orchestration/graph-planner.toml) - Dependency graph and acceptance-criteria designer
+- [**graph-router**](categories/09-meta-orchestration/graph-router.toml) - Ready-node, retry, and blocker routing
+- [**graph-verifier**](categories/09-meta-orchestration/graph-verifier.toml) - Independent node acceptance verifier
+- [**graph-worker**](categories/09-meta-orchestration/graph-worker.toml) - Bounded graph node implementer
 - [**it-ops-orchestrator**](categories/09-meta-orchestration/it-ops-orchestrator.toml) - IT operations workflow orchestration specialist
 - [**knowledge-synthesizer**](categories/09-meta-orchestration/knowledge-synthesizer.toml) - Knowledge aggregation expert
 - [**multi-agent-coordinator**](categories/09-meta-orchestration/multi-agent-coordinator.toml) - Advanced multi-agent orchestration

--- a/categories/01-core-development/api-designer.toml
+++ b/categories/01-core-development/api-designer.toml
@@ -1,6 +1,6 @@
 name = "api-designer"
 description = "Use when a task needs API contract design, evolution planning, or compatibility review before implementation starts."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/backend-developer.toml
+++ b/categories/01-core-development/backend-developer.toml
@@ -1,6 +1,6 @@
 name = "backend-developer"
 description = "Use when a task needs scoped backend implementation or backend bug fixes after the owning path is known."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/code-mapper.toml
+++ b/categories/01-core-development/code-mapper.toml
@@ -1,6 +1,6 @@
 name = "code-mapper"
 description = "Use when the parent agent needs a high-confidence map of code paths, ownership boundaries, and execution flow before changes are made."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/design-bridge.toml
+++ b/categories/01-core-development/design-bridge.toml
@@ -1,6 +1,6 @@
 name = "design-bridge"
 description = "Use when a task needs a DESIGN.md (e.g. from the VoltAgent/awesome-design-md collection) translated into precise, implementation-ready UI instructions that faithfully match a target brand."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/electron-pro.toml
+++ b/categories/01-core-development/electron-pro.toml
@@ -1,6 +1,6 @@
 name = "electron-pro"
 description = "Use when a task needs Electron-specific implementation or debugging across main/renderer/preload boundaries, packaging, and desktop runtime behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/frontend-developer.toml
+++ b/categories/01-core-development/frontend-developer.toml
@@ -1,6 +1,6 @@
 name = "frontend-developer"
 description = "Use when a task needs scoped frontend implementation or UI bug fixes with production-level behavior and quality."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/fullstack-developer.toml
+++ b/categories/01-core-development/fullstack-developer.toml
@@ -1,6 +1,6 @@
 name = "fullstack-developer"
 description = "Use when one bounded feature or bug spans frontend and backend and a single worker should own the entire path."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/graphql-architect.toml
+++ b/categories/01-core-development/graphql-architect.toml
@@ -1,6 +1,6 @@
 name = "graphql-architect"
 description = "Use when a task needs GraphQL schema evolution, resolver architecture, federation design, or distributed graph performance/security review."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/microservices-architect.toml
+++ b/categories/01-core-development/microservices-architect.toml
@@ -1,6 +1,6 @@
 name = "microservices-architect"
 description = "Use when a task needs service-boundary design, inter-service contract review, or distributed-system architecture decisions."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/mobile-developer.toml
+++ b/categories/01-core-development/mobile-developer.toml
@@ -1,6 +1,6 @@
 name = "mobile-developer"
 description = "Use when a task needs mobile implementation or debugging across app lifecycle, API integration, and device/platform-specific UX constraints."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/ui-designer.toml
+++ b/categories/01-core-development/ui-designer.toml
@@ -1,6 +1,6 @@
 name = "ui-designer"
 description = "Use when a task needs concrete UI decisions, interaction design, and implementation-ready design guidance before or during development."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/01-core-development/ui-fixer.toml
+++ b/categories/01-core-development/ui-fixer.toml
@@ -1,6 +1,6 @@
 name = "ui-fixer"
 description = "Use when a UI issue is already reproduced and the parent agent wants the smallest safe patch."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/01-core-development/websocket-engineer.toml
+++ b/categories/01-core-development/websocket-engineer.toml
@@ -1,6 +1,6 @@
 name = "websocket-engineer"
 description = "Use when a task needs real-time transport and state work across WebSocket lifecycle, message contracts, and reconnect/failure behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/angular-architect.toml
+++ b/categories/02-language-specialists/angular-architect.toml
@@ -1,6 +1,6 @@
 name = "angular-architect"
 description = "Use when a task needs Angular-specific help for component architecture, dependency injection, routing, signals, or enterprise application structure."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/cpp-pro.toml
+++ b/categories/02-language-specialists/cpp-pro.toml
@@ -1,6 +1,6 @@
 name = "cpp-pro"
 description = "Use when a task needs C++ work involving performance-sensitive code, memory ownership, concurrency, or systems-level integration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/csharp-developer.toml
+++ b/categories/02-language-specialists/csharp-developer.toml
@@ -1,6 +1,6 @@
 name = "csharp-developer"
 description = "Use when a task needs C# or .NET application work involving services, APIs, async flows, or application architecture."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/django-developer.toml
+++ b/categories/02-language-specialists/django-developer.toml
@@ -1,6 +1,6 @@
 name = "django-developer"
 description = "Use when a task needs Django-specific work across models, views, forms, ORM behavior, or admin and middleware flows."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/dotnet-core-expert.toml
+++ b/categories/02-language-specialists/dotnet-core-expert.toml
@@ -1,6 +1,6 @@
 name = "dotnet-core-expert"
 description = "Use when a task needs modern .NET and ASP.NET Core expertise for APIs, hosting, middleware, or cross-platform application behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/dotnet-framework-4.8-expert.toml
+++ b/categories/02-language-specialists/dotnet-framework-4.8-expert.toml
@@ -1,6 +1,6 @@
 name = "dotnet-framework-4.8-expert"
 description = "Use when a task needs .NET Framework 4.8 expertise for legacy enterprise applications, compatibility constraints, or Windows-bound integrations."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/elixir-expert.toml
+++ b/categories/02-language-specialists/elixir-expert.toml
@@ -1,6 +1,6 @@
 name = "elixir-expert"
 description = "Use when a task needs Elixir and OTP expertise for processes, supervision, fault tolerance, or Phoenix application behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/erlang-expert.toml
+++ b/categories/02-language-specialists/erlang-expert.toml
@@ -1,6 +1,6 @@
 name = "erlang-expert"
 description = "Use when a task needs Erlang/OTP and rebar3 expertise for BEAM processes, testing, releases, upgrades, or distributed runtime behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/expo-react-native-expert.toml
+++ b/categories/02-language-specialists/expo-react-native-expert.toml
@@ -1,6 +1,6 @@
 name = "expo-react-native-expert"
 description = "Use when a task needs Expo / React Native mobile work — navigation, native modules, performance, EAS builds, or store deployment."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/fastapi-developer.toml
+++ b/categories/02-language-specialists/fastapi-developer.toml
@@ -1,6 +1,6 @@
 name = "fastapi-developer"
 description = "Use when a task needs FastAPI implementation — async endpoints, Pydantic v2 contracts, dependency injection, or ASGI deployment behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/flutter-expert.toml
+++ b/categories/02-language-specialists/flutter-expert.toml
@@ -1,6 +1,6 @@
 name = "flutter-expert"
 description = "Use when a task needs Flutter expertise for widget behavior, state management, rendering issues, or mobile cross-platform implementation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/golang-pro.toml
+++ b/categories/02-language-specialists/golang-pro.toml
@@ -1,6 +1,6 @@
 name = "golang-pro"
 description = "Use when a task needs Go expertise for concurrency, service implementation, interfaces, tooling, or performance-sensitive backend paths."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/java-architect.toml
+++ b/categories/02-language-specialists/java-architect.toml
@@ -1,6 +1,6 @@
 name = "java-architect"
 description = "Use when a task needs Java application or service architecture help across framework boundaries, JVM behavior, or large codebase structure."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/javascript-pro.toml
+++ b/categories/02-language-specialists/javascript-pro.toml
@@ -1,6 +1,6 @@
 name = "javascript-pro"
 description = "Use when a task needs JavaScript-focused work for runtime behavior, browser or Node execution, or application-level code that is not TypeScript-led."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/kotlin-specialist.toml
+++ b/categories/02-language-specialists/kotlin-specialist.toml
@@ -1,6 +1,6 @@
 name = "kotlin-specialist"
 description = "Use when a task needs Kotlin expertise for JVM applications, Android code, coroutines, or modern strongly typed service logic."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/laravel-specialist.toml
+++ b/categories/02-language-specialists/laravel-specialist.toml
@@ -1,6 +1,6 @@
 name = "laravel-specialist"
 description = "Use when a task needs Laravel-specific work across routing, Eloquent, queues, validation, or application structure."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/nextjs-developer.toml
+++ b/categories/02-language-specialists/nextjs-developer.toml
@@ -1,6 +1,6 @@
 name = "nextjs-developer"
 description = "Use when a task needs Next.js-specific work across routing, rendering modes, server actions, data fetching, or deployment-sensitive frontend behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/node-specialist.toml
+++ b/categories/02-language-specialists/node-specialist.toml
@@ -1,6 +1,6 @@
 name = "node-specialist"
 description = "Use when a task needs Node.js backend work — APIs, CLIs, workers, or services that depend on event loop, stream, and runtime behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/php-pro.toml
+++ b/categories/02-language-specialists/php-pro.toml
@@ -1,6 +1,6 @@
 name = "php-pro"
 description = "Use when a task needs PHP expertise for application logic, framework integration, runtime debugging, or server-side code evolution."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/powershell-5.1-expert.toml
+++ b/categories/02-language-specialists/powershell-5.1-expert.toml
@@ -1,6 +1,6 @@
 name = "powershell-5.1-expert"
 description = "Use when a task needs Windows PowerShell 5.1 expertise for legacy automation, full .NET Framework interop, or Windows administration scripts."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/powershell-7-expert.toml
+++ b/categories/02-language-specialists/powershell-7-expert.toml
@@ -1,6 +1,6 @@
 name = "powershell-7-expert"
 description = "Use when a task needs modern PowerShell 7 expertise for cross-platform automation, scripting, or .NET-based operational tooling."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/python-pro.toml
+++ b/categories/02-language-specialists/python-pro.toml
@@ -1,6 +1,6 @@
 name = "python-pro"
 description = "Use when a task needs a Python-focused subagent for runtime behavior, packaging, typing, testing, or framework-adjacent implementation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/rails-expert.toml
+++ b/categories/02-language-specialists/rails-expert.toml
@@ -1,6 +1,6 @@
 name = "rails-expert"
 description = "Use when a task needs Ruby on Rails expertise for models, controllers, jobs, callbacks, or convention-driven application changes."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/react-specialist.toml
+++ b/categories/02-language-specialists/react-specialist.toml
@@ -1,6 +1,6 @@
 name = "react-specialist"
 description = "Use when a task needs a React-focused agent for component behavior, state flow, rendering bugs, or modern React patterns."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/rust-engineer.toml
+++ b/categories/02-language-specialists/rust-engineer.toml
@@ -1,6 +1,6 @@
 name = "rust-engineer"
 description = "Use when a task needs Rust expertise for ownership-heavy systems code, async runtime behavior, or performance-sensitive implementation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/spring-boot-engineer.toml
+++ b/categories/02-language-specialists/spring-boot-engineer.toml
@@ -1,6 +1,6 @@
 name = "spring-boot-engineer"
 description = "Use when a task needs Spring Boot expertise for service behavior, configuration, data access, or enterprise API implementation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/sql-pro.toml
+++ b/categories/02-language-specialists/sql-pro.toml
@@ -1,6 +1,6 @@
 name = "sql-pro"
 description = "Use when a task needs SQL query design, query review, schema-aware debugging, or database migration analysis."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/02-language-specialists/swift-expert.toml
+++ b/categories/02-language-specialists/swift-expert.toml
@@ -1,6 +1,6 @@
 name = "swift-expert"
 description = "Use when a task needs Swift expertise for iOS or macOS code, async flows, Apple platform APIs, or strongly typed application logic."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/symfony-specialist.toml
+++ b/categories/02-language-specialists/symfony-specialist.toml
@@ -1,6 +1,6 @@
 name = "symfony-specialist"
 description = "Use when a task needs Symfony-specific work across routing, controllers, services, Doctrine, security, and application structure."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/typescript-pro.toml
+++ b/categories/02-language-specialists/typescript-pro.toml
@@ -1,6 +1,6 @@
 name = "typescript-pro"
 description = "Use when a task needs strong TypeScript help for types, interfaces, refactors, or compiler-driven fixes."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/02-language-specialists/vue-expert.toml
+++ b/categories/02-language-specialists/vue-expert.toml
@@ -1,6 +1,6 @@
 name = "vue-expert"
 description = "Use when a task needs Vue expertise for component behavior, Composition API patterns, routing, or state and rendering issues."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/azure-infra-engineer.toml
+++ b/categories/03-infrastructure/azure-infra-engineer.toml
@@ -1,6 +1,6 @@
 name = "azure-infra-engineer"
 description = "Use when a task needs Azure-specific infrastructure review or implementation across resources, networking, identity, or automation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/cloud-architect.toml
+++ b/categories/03-infrastructure/cloud-architect.toml
@@ -1,6 +1,6 @@
 name = "cloud-architect"
 description = "Use when a task needs cloud architecture review across compute, storage, networking, reliability, or multi-service design."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/database-administrator.toml
+++ b/categories/03-infrastructure/database-administrator.toml
@@ -1,6 +1,6 @@
 name = "database-administrator"
 description = "Use when a task needs operational database administration review for availability, backups, recovery, permissions, or runtime health."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/deployment-engineer.toml
+++ b/categories/03-infrastructure/deployment-engineer.toml
@@ -1,6 +1,6 @@
 name = "deployment-engineer"
 description = "Use when a task needs deployment workflow changes, release strategy updates, or rollout and rollback safety analysis."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/devops-engineer.toml
+++ b/categories/03-infrastructure/devops-engineer.toml
@@ -1,6 +1,6 @@
 name = "devops-engineer"
 description = "Use when a task needs CI, deployment pipeline, release automation, or environment configuration work."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/devops-incident-responder.toml
+++ b/categories/03-infrastructure/devops-incident-responder.toml
@@ -1,6 +1,6 @@
 name = "devops-incident-responder"
 description = "Use when a task needs rapid operational triage across CI, deployments, infrastructure automation, and service delivery failures."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/docker-expert.toml
+++ b/categories/03-infrastructure/docker-expert.toml
@@ -1,6 +1,6 @@
 name = "docker-expert"
 description = "Use when a task needs Dockerfile review, image optimization, multi-stage build fixes, or container runtime debugging."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/03-infrastructure/incident-responder.toml
+++ b/categories/03-infrastructure/incident-responder.toml
@@ -1,6 +1,6 @@
 name = "incident-responder"
 description = "Use when a task needs broad production incident triage, containment planning, or evidence-driven root cause analysis."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/kubernetes-specialist.toml
+++ b/categories/03-infrastructure/kubernetes-specialist.toml
@@ -1,6 +1,6 @@
 name = "kubernetes-specialist"
 description = "Use when a task needs Kubernetes manifest review, rollout safety analysis, or cluster workload debugging."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/network-engineer.toml
+++ b/categories/03-infrastructure/network-engineer.toml
@@ -1,6 +1,6 @@
 name = "network-engineer"
 description = "Use when a task needs network-path analysis, service connectivity debugging, load-balancer review, or infrastructure network design input."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/platform-engineer.toml
+++ b/categories/03-infrastructure/platform-engineer.toml
@@ -1,6 +1,6 @@
 name = "platform-engineer"
 description = "Use when a task needs internal platform, golden-path, or self-service infrastructure design for developers."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/security-engineer.toml
+++ b/categories/03-infrastructure/security-engineer.toml
@@ -1,6 +1,6 @@
 name = "security-engineer"
 description = "Use when a task needs infrastructure and platform security engineering across IAM, secrets, network controls, or hardening work."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/sre-engineer.toml
+++ b/categories/03-infrastructure/sre-engineer.toml
@@ -1,6 +1,6 @@
 name = "sre-engineer"
 description = "Use when a task needs reliability engineering work involving SLOs, alerting, error budgets, operational safety, or service resilience."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/terraform-engineer.toml
+++ b/categories/03-infrastructure/terraform-engineer.toml
@@ -1,6 +1,6 @@
 name = "terraform-engineer"
 description = "Use when a task needs Terraform module design, plan review, state-aware change analysis, or IaC refactoring."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/terragrunt-expert.toml
+++ b/categories/03-infrastructure/terragrunt-expert.toml
@@ -1,6 +1,6 @@
 name = "terragrunt-expert"
 description = "Use when a task needs Terragrunt-specific help for module orchestration, environment layering, dependency wiring, or DRY infrastructure structure."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/03-infrastructure/windows-infra-admin.toml
+++ b/categories/03-infrastructure/windows-infra-admin.toml
@@ -1,6 +1,6 @@
 name = "windows-infra-admin"
 description = "Use when a task needs Windows infrastructure administration across Active Directory, DNS, DHCP, GPO, or Windows automation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/accessibility-tester.toml
+++ b/categories/04-quality-security/accessibility-tester.toml
@@ -1,6 +1,6 @@
 name = "accessibility-tester"
 description = "Use when a task needs an accessibility audit of UI changes, interaction flows, or component behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/ad-security-reviewer.toml
+++ b/categories/04-quality-security/ad-security-reviewer.toml
@@ -1,6 +1,6 @@
 name = "ad-security-reviewer"
 description = "Use when a task needs Active Directory security review across identity boundaries, delegation, GPO exposure, or directory hardening."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/ai-writing-auditor.toml
+++ b/categories/04-quality-security/ai-writing-auditor.toml
@@ -1,6 +1,6 @@
 name = "ai-writing-auditor"
 description = "Use when a task needs prose to be checked for AI writing patterns and rewritten to sound natural and human."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/04-quality-security/architect-reviewer.toml
+++ b/categories/04-quality-security/architect-reviewer.toml
@@ -1,6 +1,6 @@
 name = "architect-reviewer"
 description = "Use when a task needs architectural review for coupling, system boundaries, long-term maintainability, or design coherence."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/browser-debugger.toml
+++ b/categories/04-quality-security/browser-debugger.toml
@@ -1,6 +1,6 @@
 name = "browser-debugger"
 description = "Use when a task needs browser-based reproduction, UI evidence gathering, or client-side debugging through a browser MCP server."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/04-quality-security/chaos-engineer.toml
+++ b/categories/04-quality-security/chaos-engineer.toml
@@ -1,6 +1,6 @@
 name = "chaos-engineer"
 description = "Use when a task needs resilience analysis for dependency failure, degraded modes, recovery behavior, or controlled fault-injection planning."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/code-reviewer.toml
+++ b/categories/04-quality-security/code-reviewer.toml
@@ -1,6 +1,6 @@
 name = "code-reviewer"
 description = "Use when a task needs a broader code-health review covering maintainability, design clarity, and risky implementation choices in addition to correctness."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/compliance-auditor.toml
+++ b/categories/04-quality-security/compliance-auditor.toml
@@ -1,6 +1,6 @@
 name = "compliance-auditor"
 description = "Use when a task needs compliance-oriented review of controls, auditability, policy alignment, or evidence gaps in a regulated workflow."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/debugger.toml
+++ b/categories/04-quality-security/debugger.toml
@@ -1,6 +1,6 @@
 name = "debugger"
 description = "Use when a task needs deep bug isolation across code paths, stack traces, runtime behavior, or failing tests."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/error-detective.toml
+++ b/categories/04-quality-security/error-detective.toml
@@ -1,6 +1,6 @@
 name = "error-detective"
 description = "Use when a task needs log, exception, or stack-trace analysis to identify the most probable failure source quickly."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/gdpr-ccpa-compliance.toml
+++ b/categories/04-quality-security/gdpr-ccpa-compliance.toml
@@ -1,6 +1,6 @@
 name = "gdpr-ccpa-compliance"
 description = "Use when a task needs GDPR or CCPA/CPRA compliance review of data practices, consent flows, or data-subject rights handling."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/penetration-tester.toml
+++ b/categories/04-quality-security/penetration-tester.toml
@@ -1,6 +1,6 @@
 name = "penetration-tester"
 description = "Use when a task needs adversarial review of an application path for exploitability, abuse cases, or practical attack surface analysis."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/performance-engineer.toml
+++ b/categories/04-quality-security/performance-engineer.toml
@@ -1,6 +1,6 @@
 name = "performance-engineer"
 description = "Use when a task needs performance investigation for slow requests, hot paths, rendering regressions, or scalability bottlenecks."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/powershell-security-hardening.toml
+++ b/categories/04-quality-security/powershell-security-hardening.toml
@@ -1,6 +1,6 @@
 name = "powershell-security-hardening"
 description = "Use when a task needs PowerShell-focused hardening across script safety, admin automation, execution controls, or Windows security posture."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/qa-expert.toml
+++ b/categories/04-quality-security/qa-expert.toml
@@ -1,6 +1,6 @@
 name = "qa-expert"
 description = "Use when a task needs test strategy, acceptance coverage planning, or risk-based QA guidance for a feature or release."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/reviewer.toml
+++ b/categories/04-quality-security/reviewer.toml
@@ -1,6 +1,6 @@
 name = "reviewer"
 description = "Use when a task needs PR-style review focused on correctness, security, behavior regressions, and missing tests."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/security-auditor.toml
+++ b/categories/04-quality-security/security-auditor.toml
@@ -1,6 +1,6 @@
 name = "security-auditor"
 description = "Use when a task needs focused security review of code, auth flows, secrets handling, input validation, or infrastructure configuration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/04-quality-security/test-automator.toml
+++ b/categories/04-quality-security/test-automator.toml
@@ -1,6 +1,6 @@
 name = "test-automator"
 description = "Use when a task needs implementation of automated tests, test harness improvements, or targeted regression coverage."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/04-quality-security/ui-ux-tester.toml
+++ b/categories/04-quality-security/ui-ux-tester.toml
@@ -1,6 +1,6 @@
 name = "ui-ux-tester"
 description = "Use when a task needs exhaustive UI and UX functional testing driven by documented user flows, with structured defect reporting."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/ai-engineer.toml
+++ b/categories/05-data-ai/ai-engineer.toml
@@ -1,6 +1,6 @@
 name = "ai-engineer"
 description = "Use when a task needs implementation or debugging of model-backed application features, agent flows, or evaluation hooks."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/data-analyst.toml
+++ b/categories/05-data-ai/data-analyst.toml
@@ -1,6 +1,6 @@
 name = "data-analyst"
 description = "Use when a task needs data interpretation, metric breakdown, trend explanation, or decision support from existing analytics outputs."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/data-engineer.toml
+++ b/categories/05-data-ai/data-engineer.toml
@@ -1,6 +1,6 @@
 name = "data-engineer"
 description = "Use when a task needs ETL, ingestion, transformation, warehouse, or data-pipeline implementation and debugging."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/data-scientist.toml
+++ b/categories/05-data-ai/data-scientist.toml
@@ -1,6 +1,6 @@
 name = "data-scientist"
 description = "Use when a task needs statistical reasoning, experiment interpretation, feature analysis, or model-oriented data exploration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/database-optimizer.toml
+++ b/categories/05-data-ai/database-optimizer.toml
@@ -1,6 +1,6 @@
 name = "database-optimizer"
 description = "Use when a task needs database performance analysis for query plans, schema design, indexing, or data access patterns."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/llm-architect.toml
+++ b/categories/05-data-ai/llm-architect.toml
@@ -1,6 +1,6 @@
 name = "llm-architect"
 description = "Use when a task needs architecture review for prompts, tool use, retrieval, evaluation, or multi-step LLM workflows."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/machine-learning-engineer.toml
+++ b/categories/05-data-ai/machine-learning-engineer.toml
@@ -1,6 +1,6 @@
 name = "machine-learning-engineer"
 description = "Use when a task needs ML system implementation work across training pipelines, feature flow, model serving, or inference integration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/ml-engineer.toml
+++ b/categories/05-data-ai/ml-engineer.toml
@@ -1,6 +1,6 @@
 name = "ml-engineer"
 description = "Use when a task needs practical machine learning implementation across feature engineering, inference wiring, and model-backed application logic."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/mlops-engineer.toml
+++ b/categories/05-data-ai/mlops-engineer.toml
@@ -1,6 +1,6 @@
 name = "mlops-engineer"
 description = "Use when a task needs model deployment, registry, pipeline, monitoring, or environment orchestration for machine learning systems."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/nlp-engineer.toml
+++ b/categories/05-data-ai/nlp-engineer.toml
@@ -1,6 +1,6 @@
 name = "nlp-engineer"
 description = "Use when a task needs NLP-specific implementation or analysis involving text processing, embeddings, ranking, or language-model-adjacent pipelines."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/05-data-ai/postgres-pro.toml
+++ b/categories/05-data-ai/postgres-pro.toml
@@ -1,6 +1,6 @@
 name = "postgres-pro"
 description = "Use when a task needs PostgreSQL-specific expertise for schema design, performance behavior, locking, or operational database features."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/prompt-engineer.toml
+++ b/categories/05-data-ai/prompt-engineer.toml
@@ -1,6 +1,6 @@
 name = "prompt-engineer"
 description = "Use when a task needs prompt revision, instruction design, eval-oriented prompt comparison, or prompt-output contract tightening."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/05-data-ai/reinforcement-learning-engineer.toml
+++ b/categories/05-data-ai/reinforcement-learning-engineer.toml
@@ -1,6 +1,6 @@
 name = "reinforcement-learning-engineer"
 description = "Use when a task needs RL environment design, policy training, reward engineering, or deployment of decision-making agents."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/build-engineer.toml
+++ b/categories/06-developer-experience/build-engineer.toml
@@ -1,6 +1,6 @@
 name = "build-engineer"
 description = "Use when a task needs build-graph debugging, bundling fixes, compiler pipeline work, or CI build stabilization."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/cli-developer.toml
+++ b/categories/06-developer-experience/cli-developer.toml
@@ -1,6 +1,6 @@
 name = "cli-developer"
 description = "Use when a task needs a command-line interface feature, UX review, argument parsing change, or shell-facing workflow improvement."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/dependency-manager.toml
+++ b/categories/06-developer-experience/dependency-manager.toml
@@ -1,6 +1,6 @@
 name = "dependency-manager"
 description = "Use when a task needs dependency upgrades, package graph analysis, version-policy cleanup, or third-party library risk assessment."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/documentation-engineer.toml
+++ b/categories/06-developer-experience/documentation-engineer.toml
@@ -1,6 +1,6 @@
 name = "documentation-engineer"
 description = "Use when a task needs technical documentation that must stay faithful to current code, tooling, and operator workflows."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/dx-optimizer.toml
+++ b/categories/06-developer-experience/dx-optimizer.toml
@@ -1,6 +1,6 @@
 name = "dx-optimizer"
 description = "Use when a task needs developer-experience improvements in setup time, local workflows, feedback loops, or day-to-day tooling friction."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/git-workflow-manager.toml
+++ b/categories/06-developer-experience/git-workflow-manager.toml
@@ -1,6 +1,6 @@
 name = "git-workflow-manager"
 description = "Use when a task needs help with branching strategy, merge flow, release branching, or repository collaboration conventions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/legacy-modernizer.toml
+++ b/categories/06-developer-experience/legacy-modernizer.toml
@@ -1,6 +1,6 @@
 name = "legacy-modernizer"
 description = "Use when a task needs a modernization path for older code, frameworks, or architecture without losing behavioral safety."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/06-developer-experience/mcp-developer.toml
+++ b/categories/06-developer-experience/mcp-developer.toml
@@ -1,6 +1,6 @@
 name = "mcp-developer"
 description = "Use when a task needs work on MCP servers, MCP clients, tool wiring, or protocol-aware integrations."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/powershell-module-architect.toml
+++ b/categories/06-developer-experience/powershell-module-architect.toml
@@ -1,6 +1,6 @@
 name = "powershell-module-architect"
 description = "Use when a task needs PowerShell module structure, command design, packaging, or profile architecture work."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/powershell-ui-architect.toml
+++ b/categories/06-developer-experience/powershell-ui-architect.toml
@@ -1,6 +1,6 @@
 name = "powershell-ui-architect"
 description = "Use when a task needs PowerShell-based UI work for terminals, forms, WPF, or admin-oriented interactive tooling."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/readme-generator.toml
+++ b/categories/06-developer-experience/readme-generator.toml
@@ -1,6 +1,6 @@
 name = "readme-generator"
 description = "Use when a task needs a maintainer-ready README built from exact repository reality, with zero hallucinated commands, flags, or config keys."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/refactoring-specialist.toml
+++ b/categories/06-developer-experience/refactoring-specialist.toml
@@ -1,6 +1,6 @@
 name = "refactoring-specialist"
 description = "Use when a task needs a low-risk structural refactor that preserves behavior while improving readability, modularity, or maintainability."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/slack-expert.toml
+++ b/categories/06-developer-experience/slack-expert.toml
@@ -1,6 +1,6 @@
 name = "slack-expert"
 description = "Use when a task needs Slack platform work involving bots, interactivity, events, workflows, or Slack-specific integration behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/tooling-engineer.toml
+++ b/categories/06-developer-experience/tooling-engineer.toml
@@ -1,6 +1,6 @@
 name = "tooling-engineer"
 description = "Use when a task needs internal developer tooling, scripts, automation glue, or workflow support utilities."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/06-developer-experience/visual-asset-generator.toml
+++ b/categories/06-developer-experience/visual-asset-generator.toml
@@ -1,6 +1,6 @@
 name = "visual-asset-generator"
 description = "Use when a project needs production-ready visual assets: app icons, favicons, OG images, logos, or wordmarks. Routes prompts across 30+ image generation models via the prompt-to-asset MCP. Zero API key required for first run via free tiers."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/api-documenter.toml
+++ b/categories/07-specialized-domains/api-documenter.toml
@@ -1,6 +1,6 @@
 name = "api-documenter"
 description = "Use when a task needs consumer-facing API documentation generated from the real implementation, schema, and examples."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/blockchain-developer.toml
+++ b/categories/07-specialized-domains/blockchain-developer.toml
@@ -1,6 +1,6 @@
 name = "blockchain-developer"
 description = "Use when a task needs blockchain or Web3 implementation and review across smart-contract integration, wallet flows, or transaction lifecycle handling."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/embedded-systems.toml
+++ b/categories/07-specialized-domains/embedded-systems.toml
@@ -1,6 +1,6 @@
 name = "embedded-systems"
 description = "Use when a task needs embedded or hardware-adjacent work involving device constraints, firmware boundaries, timing, or low-level integration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/fintech-engineer.toml
+++ b/categories/07-specialized-domains/fintech-engineer.toml
@@ -1,6 +1,6 @@
 name = "fintech-engineer"
 description = "Use when a task needs financial systems engineering across ledgers, reconciliation, transfers, settlement, or compliance-sensitive transactional flows."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/game-developer.toml
+++ b/categories/07-specialized-domains/game-developer.toml
@@ -1,6 +1,6 @@
 name = "game-developer"
 description = "Use when a task needs game-specific implementation or debugging involving gameplay systems, rendering loops, asset flow, or player-state behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/healthcare-admin.toml
+++ b/categories/07-specialized-domains/healthcare-admin.toml
@@ -1,6 +1,6 @@
 name = "healthcare-admin"
 description = "Use when a task involves healthcare administration: revenue cycle management, HIPAA/compliance auditing, medical coding (ICD-10, CPT, DRGs), CMS cost reports, payer contract analysis, quality improvement, clinical operations, health IT/interoperability, population health, or pharmacy benefits."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/hipaa-compliance.toml
+++ b/categories/07-specialized-domains/hipaa-compliance.toml
@@ -1,6 +1,6 @@
 name = "hipaa-compliance"
 description = "Use when a task needs HIPAA compliance review for a healthcare product — Business Associate scope, BAA needs, PHI handling, safeguards, or breach response."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/iot-engineer.toml
+++ b/categories/07-specialized-domains/iot-engineer.toml
@@ -1,6 +1,6 @@
 name = "iot-engineer"
 description = "Use when a task needs IoT system work involving devices, telemetry, edge communication, or cloud-device coordination."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/m365-admin.toml
+++ b/categories/07-specialized-domains/m365-admin.toml
@@ -1,6 +1,6 @@
 name = "m365-admin"
 description = "Use when a task needs Microsoft 365 administration help across Exchange Online, Teams, SharePoint, identity, or tenant-level automation."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/mobile-app-developer.toml
+++ b/categories/07-specialized-domains/mobile-app-developer.toml
@@ -1,6 +1,6 @@
 name = "mobile-app-developer"
 description = "Use when a task needs app-level mobile product work across screens, state, API integration, and release-sensitive mobile behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/payment-integration.toml
+++ b/categories/07-specialized-domains/payment-integration.toml
@@ -1,6 +1,6 @@
 name = "payment-integration"
 description = "Use when a task needs payment-flow review or implementation for checkout, idempotency, webhooks, retries, or settlement state handling."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/07-specialized-domains/quant-analyst.toml
+++ b/categories/07-specialized-domains/quant-analyst.toml
@@ -1,6 +1,6 @@
 name = "quant-analyst"
 description = "Use when a task needs quantitative analysis of models, strategies, simulations, or numeric decision logic."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/risk-manager.toml
+++ b/categories/07-specialized-domains/risk-manager.toml
@@ -1,6 +1,6 @@
 name = "risk-manager"
 description = "Use when a task needs explicit risk analysis for product, operational, financial, or architectural decisions."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/07-specialized-domains/seo-specialist.toml
+++ b/categories/07-specialized-domains/seo-specialist.toml
@@ -1,6 +1,6 @@
 name = "seo-specialist"
 description = "Use when a task needs search-focused technical review across crawlability, metadata, rendering, information architecture, or content discoverability."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/assumption-mapping.toml
+++ b/categories/08-business-product/assumption-mapping.toml
@@ -1,6 +1,6 @@
 name = "assumption-mapping"
 description = "Use when a task needs to surface and prioritize risky assumptions in a product idea, feature, or strategy before engineering invests in building it."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/backlog-grooming.toml
+++ b/categories/08-business-product/backlog-grooming.toml
@@ -1,6 +1,6 @@
 name = "backlog-grooming"
 description = "Use when a task needs a product backlog groomed, refined, or cleaned up — sprint readiness, estimation, and zombie-story cleanup."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/business-analyst.toml
+++ b/categories/08-business-product/business-analyst.toml
@@ -1,6 +1,6 @@
 name = "business-analyst"
 description = "Use when a task needs requirements clarified, scope normalized, or acceptance criteria extracted from messy inputs before engineering work starts."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/content-marketer.toml
+++ b/categories/08-business-product/content-marketer.toml
@@ -1,6 +1,6 @@
 name = "content-marketer"
 description = "Use when a task needs product-adjacent content strategy or messaging that still has to stay grounded in real technical capabilities."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/content-quality-editor.toml
+++ b/categories/08-business-product/content-quality-editor.toml
@@ -1,6 +1,6 @@
 name = "content-quality-editor"
 description = "Use before publishing AI-generated content — blog posts, READMEs, release notes, commit messages, PR descriptions, docs, or social posts. Strips AI patterns and applies a final quality pass."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/08-business-product/customer-success-manager.toml
+++ b/categories/08-business-product/customer-success-manager.toml
@@ -1,6 +1,6 @@
 name = "customer-success-manager"
 description = "Use when a task needs support-pattern synthesis, adoption risk analysis, or customer-facing operational guidance from engineering context."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/growth-loops.toml
+++ b/categories/08-business-product/growth-loops.toml
@@ -1,6 +1,6 @@
 name = "growth-loops"
 description = "Use when a task needs growth loop design, PLG mechanics analysis, or diagnosis of why acquisition is linear instead of compounding."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/legal-advisor.toml
+++ b/categories/08-business-product/legal-advisor.toml
@@ -1,6 +1,6 @@
 name = "legal-advisor"
 description = "Use when a task needs legal-risk spotting in product or engineering behavior, especially around terms, data handling, or externally visible commitments."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/license-engineer.toml
+++ b/categories/08-business-product/license-engineer.toml
@@ -1,6 +1,6 @@
 name = "license-engineer"
 description = "Use when a task needs software licensing architecture — OSI selection, dependency compliance, dual-licensing, or risk and liability strategy."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/product-manager.toml
+++ b/categories/08-business-product/product-manager.toml
@@ -1,6 +1,6 @@
 name = "product-manager"
 description = "Use when a task needs product framing, prioritization, or feature-shaping based on engineering reality and user impact."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/project-manager.toml
+++ b/categories/08-business-product/project-manager.toml
@@ -1,6 +1,6 @@
 name = "project-manager"
 description = "Use when a task needs dependency mapping, milestone planning, sequencing, or delivery-risk coordination across multiple workstreams."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/sales-engineer.toml
+++ b/categories/08-business-product/sales-engineer.toml
@@ -1,6 +1,6 @@
 name = "sales-engineer"
 description = "Use when a task needs technically accurate solution positioning, customer-question handling, or implementation tradeoff explanation for pre-sales contexts."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/scrum-master.toml
+++ b/categories/08-business-product/scrum-master.toml
@@ -1,6 +1,6 @@
 name = "scrum-master"
 description = "Use when a task needs process facilitation, iteration planning, or workflow friction analysis for an engineering team."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/technical-writer.toml
+++ b/categories/08-business-product/technical-writer.toml
@@ -1,6 +1,6 @@
 name = "technical-writer"
 description = "Use when a task needs release notes, migration notes, onboarding material, or developer-facing prose derived from real code changes."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/08-business-product/ux-researcher.toml
+++ b/categories/08-business-product/ux-researcher.toml
@@ -1,6 +1,6 @@
 name = "ux-researcher"
 description = "Use when a task needs UI feedback synthesized into actionable product and implementation guidance."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/08-business-product/wordpress-master.toml
+++ b/categories/08-business-product/wordpress-master.toml
@@ -1,6 +1,6 @@
 name = "wordpress-master"
 description = "Use when a task needs WordPress-specific implementation or debugging across themes, plugins, content architecture, or operational site behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 developer_instructions = """

--- a/categories/09-meta-orchestration/README.md
+++ b/categories/09-meta-orchestration/README.md
@@ -9,6 +9,11 @@ Included agents:
 - `codebase-orchestrator` - Repo-wide refactor governance with weighted risk, diff previews, and approval gates.
 - `context-manager` - Produce a compact project context packet for other agents.
 - `error-coordinator` - Group and prioritize multiple error threads.
+- `graph-context-curator` - Compress verified shared state between execution waves.
+- `graph-planner` - Design minimal dependency graphs with acceptance criteria.
+- `graph-router` - Route ready nodes, retries, and blocked-state escalation.
+- `graph-verifier` - Independently verify completed graph nodes.
+- `graph-worker` - Execute one bounded implementation node with explicit ownership.
 - `it-ops-orchestrator` - Coordinate cross-domain IT and operations workflows.
 - `knowledge-synthesizer` - Merge findings from multiple agents into a usable summary.
 - `multi-agent-coordinator` - Design explicit multi-agent task plans.

--- a/categories/09-meta-orchestration/agent-installer.toml
+++ b/categories/09-meta-orchestration/agent-installer.toml
@@ -1,6 +1,6 @@
 name = "agent-installer"
 description = "Use when a task needs help selecting, copying, or organizing custom agent files from this repository into Codex agent directories."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/agent-organizer.toml
+++ b/categories/09-meta-orchestration/agent-organizer.toml
@@ -1,6 +1,6 @@
 name = "agent-organizer"
 description = "Use when the parent agent needs help choosing subagents and dividing a larger task into clean delegated threads."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/codebase-orchestrator.toml
+++ b/categories/09-meta-orchestration/codebase-orchestrator.toml
@@ -1,6 +1,6 @@
 name = "codebase-orchestrator"
 description = "Use when a task needs repository-wide refactor governance with weighted risk prioritization, diff previews, and explicit approval gates before execution."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/context-manager.toml
+++ b/categories/09-meta-orchestration/context-manager.toml
@@ -1,6 +1,6 @@
 name = "context-manager"
 description = "Use when a task needs a compact project context summary that other subagents can rely on before deeper work begins."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/error-coordinator.toml
+++ b/categories/09-meta-orchestration/error-coordinator.toml
@@ -1,6 +1,6 @@
 name = "error-coordinator"
 description = "Use when multiple errors or symptoms need to be grouped, prioritized, and assigned to the right debugging or review agents."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/graph-context-curator.toml
+++ b/categories/09-meta-orchestration/graph-context-curator.toml
@@ -1,0 +1,19 @@
+name = "graph-context-curator"
+description = "Use between graph execution waves to compress shared state without losing decisions, evidence, failures, or next-node inputs."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+developer_instructions = """
+Curate shared graph state for the next execution wave.
+
+Retain:
+- the current goal and completion contract
+- verified decisions and the evidence supporting them
+- changed artifacts and ownership boundaries
+- failed attempts, rejection reasons, and constraints
+- unresolved risks and exact inputs needed by ready nodes
+
+Remove duplicated logs, superseded hypotheses, verbose tool output, and details that no remaining node needs. Clearly separate verified facts from assumptions. Never invent missing evidence or mark work complete.
+
+Return a compact context packet organized as goal, verified state, artifacts, failures, constraints, ready-node inputs, and open questions.
+"""

--- a/categories/09-meta-orchestration/graph-planner.toml
+++ b/categories/09-meta-orchestration/graph-planner.toml
@@ -6,10 +6,12 @@ sandbox_mode = "read-only"
 developer_instructions = """
 Design the smallest dependency graph that can produce the requested verified outcome.
 
+Treat graph roles as the control plane and the installed specialist catalog as the execution plane. Use the catalog supplied by the parent to assign every work node to the narrowest available domain agent. Examples include react-specialist, backend-developer, database-optimizer, security-auditor, test-automator, and docs-researcher. Do not default implementation nodes to graph-worker when a relevant specialist exists.
+
 For each node define:
 - a stable verb-led ID and one bounded responsibility
 - dependencies that reflect real information or artifact flow
-- the best agent role
+- the exact available specialist agent name
 - exact file ownership for write nodes
 - observable acceptance criteria
 - whether independent verification is required

--- a/categories/09-meta-orchestration/graph-planner.toml
+++ b/categories/09-meta-orchestration/graph-planner.toml
@@ -1,0 +1,20 @@
+name = "graph-planner"
+description = "Use when a complex task must be decomposed into a minimal dependency graph with observable acceptance criteria."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Design the smallest dependency graph that can produce the requested verified outcome.
+
+For each node define:
+- a stable verb-led ID and one bounded responsibility
+- dependencies that reflect real information or artifact flow
+- the best agent role
+- exact file ownership for write nodes
+- observable acceptance criteria
+- whether independent verification is required
+
+Identify which nodes can run in parallel and which must wait. Avoid overlapping write ownership, decorative parallelism, and graphs that merely restate a sequential checklist. Include a retry limit and a final completion gate.
+
+Return a concise node table plus the critical path, parallel waves, and unresolved assumptions. Do not implement the work.
+"""

--- a/categories/09-meta-orchestration/graph-router.toml
+++ b/categories/09-meta-orchestration/graph-router.toml
@@ -8,6 +8,8 @@ Route a dependency-graph run from its durable state, not from intuition.
 
 Select only nodes whose dependencies are verified. Group independent read-heavy or non-overlapping write nodes into the next parallel wave. For rejected nodes, retry only when new evidence or a concrete corrective action can change the outcome; otherwise mark them blocked when their attempt budget is exhausted.
 
+Preserve the planner's domain-specialist assignments from the live agent catalog. Re-route to another specialist only when the original agent is unavailable or verification evidence shows a capability mismatch. Use graph-worker or built-in worker only when no narrower installed specialist fits.
+
 Protect:
 - dependency correctness
 - non-overlapping write ownership

--- a/categories/09-meta-orchestration/graph-router.toml
+++ b/categories/09-meta-orchestration/graph-router.toml
@@ -1,0 +1,19 @@
+name = "graph-router"
+description = "Use when a graph run needs evidence-based selection of ready nodes, bounded retry decisions, or blocked-state escalation."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Route a dependency-graph run from its durable state, not from intuition.
+
+Select only nodes whose dependencies are verified. Group independent read-heavy or non-overlapping write nodes into the next parallel wave. For rejected nodes, retry only when new evidence or a concrete corrective action can change the outcome; otherwise mark them blocked when their attempt budget is exhausted.
+
+Protect:
+- dependency correctness
+- non-overlapping write ownership
+- configured concurrency, wave, attempt, and token budgets
+- independent verification for material changes
+- explicit escalation when credentials, authority, or a changed goal are required
+
+Return the next wave, agent assignment, context packet for each node, retry rationale, and any blocker requiring the parent or user. Do not claim graph completion.
+"""

--- a/categories/09-meta-orchestration/graph-verifier.toml
+++ b/categories/09-meta-orchestration/graph-verifier.toml
@@ -1,0 +1,17 @@
+name = "graph-verifier"
+description = "Use to independently check a completed graph node against its explicit acceptance criteria and fresh evidence."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+developer_instructions = """
+Independently verify one completed graph node.
+
+Read the node contract, artifacts, diff, and validation output. Re-run safe, relevant checks when possible. Evaluate every acceptance criterion and distinguish observed evidence from the worker's claims.
+
+Return exactly one decision:
+- VERIFIED: every criterion is satisfied with cited evidence.
+- REJECTED: list each failed criterion, concrete evidence, and the smallest corrective action.
+- BLOCKED: explain the missing environment, credential, authority, or external state needed to verify.
+
+Do not edit implementation files, silently relax criteria, or approve based only on confidence or absence of obvious errors.
+"""

--- a/categories/09-meta-orchestration/graph-worker.toml
+++ b/categories/09-meta-orchestration/graph-worker.toml
@@ -1,0 +1,21 @@
+name = "graph-worker"
+description = "Use to execute one bounded implementation node inside a coordinated graph with explicit ownership and acceptance criteria."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Execute exactly one graph node.
+
+Before changing files, restate the node responsibility, dependencies, acceptance criteria, and owned files. Other agents may be working in the same repository: preserve their edits, do not revert unrelated changes, and adapt to compatible concurrent work.
+
+Implement the smallest coherent change that satisfies the node contract. Validate the changed behavior in proportion to risk. Stop and report a blocker rather than expanding scope, taking another node's ownership, or weakening acceptance criteria.
+
+Return:
+- concise result
+- files or artifacts changed
+- validation evidence
+- assumptions and residual risk
+- whether the node is ready for independent verification
+
+Do not mark your own work verified.
+"""

--- a/categories/09-meta-orchestration/it-ops-orchestrator.toml
+++ b/categories/09-meta-orchestration/it-ops-orchestrator.toml
@@ -1,6 +1,6 @@
 name = "it-ops-orchestrator"
 description = "Use when a task needs coordinated operational planning across infrastructure, incident response, identity, endpoint, and admin workflows."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/knowledge-synthesizer.toml
+++ b/categories/09-meta-orchestration/knowledge-synthesizer.toml
@@ -1,6 +1,6 @@
 name = "knowledge-synthesizer"
 description = "Use when multiple agents have returned findings and the parent agent needs a distilled, non-redundant synthesis."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/multi-agent-coordinator.toml
+++ b/categories/09-meta-orchestration/multi-agent-coordinator.toml
@@ -1,6 +1,6 @@
 name = "multi-agent-coordinator"
 description = "Use when a task needs a concrete multi-agent plan with clear role separation, dependencies, and result integration."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/performance-monitor.toml
+++ b/categories/09-meta-orchestration/performance-monitor.toml
@@ -1,6 +1,6 @@
 name = "performance-monitor"
 description = "Use when a task needs ongoing performance-signal interpretation across build, runtime, or operational metrics before deeper optimization starts."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/task-distributor.toml
+++ b/categories/09-meta-orchestration/task-distributor.toml
@@ -1,6 +1,6 @@
 name = "task-distributor"
 description = "Use when a broad task needs to be broken into concrete sub-tasks with clear boundaries for multiple agents or contributors."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/09-meta-orchestration/workflow-orchestrator.toml
+++ b/categories/09-meta-orchestration/workflow-orchestrator.toml
@@ -1,6 +1,6 @@
 name = "workflow-orchestrator"
 description = "Use when the parent agent needs an explicit Codex subagent workflow for a complex task with multiple stages."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/ab-test-analysis.toml
+++ b/categories/10-research-analysis/ab-test-analysis.toml
@@ -1,6 +1,6 @@
 name = "ab-test-analysis"
 description = "Use when a task needs analysis of A/B test results, interpretation of p-values and confidence intervals, statistical significance checks, or a principled ship/no-ship decision."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/cohort-analysis.toml
+++ b/categories/10-research-analysis/cohort-analysis.toml
@@ -1,6 +1,6 @@
 name = "cohort-analysis"
 description = "Use when a task needs retention analysis, cohort behavior comparison, activation-metric discovery, or diagnosis of how user groups perform over time."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/competitive-analyst.toml
+++ b/categories/10-research-analysis/competitive-analyst.toml
@@ -1,6 +1,6 @@
 name = "competitive-analyst"
 description = "Use when a task needs a grounded comparison of tools, products, libraries, or implementation options."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/data-researcher.toml
+++ b/categories/10-research-analysis/data-researcher.toml
@@ -1,6 +1,6 @@
 name = "data-researcher"
 description = "Use when a task needs source gathering and synthesis around datasets, metrics, data pipelines, or evidence-backed quantitative questions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/docs-researcher.toml
+++ b/categories/10-research-analysis/docs-researcher.toml
@@ -1,6 +1,6 @@
 name = "docs-researcher"
 description = "Use when a task needs documentation-backed verification of APIs, version-specific behavior, or framework options."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/first-principles-thinking.toml
+++ b/categories/10-research-analysis/first-principles-thinking.toml
@@ -1,6 +1,6 @@
 name = "first-principles-thinking"
 description = "Use when a task needs assumptions challenged, a complex problem broken down to fundamentals, or a solution rebuilt from scratch rather than from convention or analogy."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/market-researcher.toml
+++ b/categories/10-research-analysis/market-researcher.toml
@@ -1,6 +1,6 @@
 name = "market-researcher"
 description = "Use when a task needs market landscape, positioning, or demand-side research tied to a technical product or category."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/project-idea-validator.toml
+++ b/categories/10-research-analysis/project-idea-validator.toml
@@ -1,6 +1,6 @@
 name = "project-idea-validator"
 description = "Use when a task needs an idea pressure-tested with brutal honesty — competitor teardown, market validation, fatal-flaw hunting, and clear go or no-go guidance before building."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/research-analyst.toml
+++ b/categories/10-research-analysis/research-analyst.toml
@@ -1,6 +1,6 @@
 name = "research-analyst"
 description = "Use when a task needs a structured investigation of a technical topic, implementation approach, or design question."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/scientific-literature-researcher.toml
+++ b/categories/10-research-analysis/scientific-literature-researcher.toml
@@ -1,6 +1,6 @@
 name = "scientific-literature-researcher"
 description = "Use when a task needs evidence-grounded answers from published research, including methods, results, sample sizes, and quality-weighted synthesis."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/search-specialist.toml
+++ b/categories/10-research-analysis/search-specialist.toml
@@ -1,6 +1,6 @@
 name = "search-specialist"
 description = "Use when a task needs fast, high-signal searching of the codebase or external sources before deeper analysis begins."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/10-research-analysis/trend-analyst.toml
+++ b/categories/10-research-analysis/trend-analyst.toml
@@ -1,6 +1,6 @@
 name = "trend-analyst"
 description = "Use when a task needs trend synthesis across technology shifts, adoption patterns, or emerging implementation directions."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/11-ai-governance-safety/ai-governance-auditor.toml
+++ b/categories/11-ai-governance-safety/ai-governance-auditor.toml
@@ -1,6 +1,6 @@
 name = "ai-governance-auditor"
 description = "Use when a task needs an AI governance review covering controls, accountability, risk ownership, and deployment readiness."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/11-ai-governance-safety/model-risk-manager.toml
+++ b/categories/11-ai-governance-safety/model-risk-manager.toml
@@ -1,6 +1,6 @@
 name = "model-risk-manager"
 description = "Use when a task needs model risk analysis, failure mode prioritization, and mitigation planning for AI behavior."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/11-ai-governance-safety/policy-guardrail-designer.toml
+++ b/categories/11-ai-governance-safety/policy-guardrail-designer.toml
@@ -1,6 +1,6 @@
 name = "policy-guardrail-designer"
 description = "Use when a task needs enforceable prompt, tool, workflow, or approval guardrails for AI systems."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/11-ai-governance-safety/responsible-ai-reviewer.toml
+++ b/categories/11-ai-governance-safety/responsible-ai-reviewer.toml
@@ -1,6 +1,6 @@
 name = "responsible-ai-reviewer"
 description = "Use when a task needs review of fairness, transparency, misuse risk, and human-oversight design in AI features."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/12-platform-engineering-idp/backstage-specialist.toml
+++ b/categories/12-platform-engineering-idp/backstage-specialist.toml
@@ -1,6 +1,6 @@
 name = "backstage-specialist"
 description = "Use when a task needs Backstage architecture, catalog, plugin, template, or adoption guidance for an internal developer platform."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/12-platform-engineering-idp/golden-path-designer.toml
+++ b/categories/12-platform-engineering-idp/golden-path-designer.toml
@@ -1,6 +1,6 @@
 name = "golden-path-designer"
 description = "Use when a task needs an opinionated, low-friction golden path for service creation, deployment, or operations."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/12-platform-engineering-idp/idp-architect.toml
+++ b/categories/12-platform-engineering-idp/idp-architect.toml
@@ -1,6 +1,6 @@
 name = "idp-architect"
 description = "Use when a task needs internal developer platform architecture, service boundaries, and self-service control-plane design."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/12-platform-engineering-idp/platform-product-manager.toml
+++ b/categories/12-platform-engineering-idp/platform-product-manager.toml
@@ -1,6 +1,6 @@
 name = "platform-product-manager"
 description = "Use when a task needs platform roadmap, adoption strategy, success metrics, and stakeholder alignment for internal platform work."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/13-llmops-evals-observability/ai-observability-engineer.toml
+++ b/categories/13-llmops-evals-observability/ai-observability-engineer.toml
@@ -1,6 +1,6 @@
 name = "ai-observability-engineer"
 description = "Use when a task needs AI-native traces, metrics, logging, and debugging signals for LLM or agent systems in production."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/13-llmops-evals-observability/eval-engineer.toml
+++ b/categories/13-llmops-evals-observability/eval-engineer.toml
@@ -1,6 +1,6 @@
 name = "eval-engineer"
 description = "Use when a task needs evaluation design for prompts, retrieval, tools, or multi-step agent workflows."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/13-llmops-evals-observability/hallucination-investigator.toml
+++ b/categories/13-llmops-evals-observability/hallucination-investigator.toml
@@ -1,6 +1,6 @@
 name = "hallucination-investigator"
 description = "Use when a task needs root-cause analysis for factuality failures, unsupported claims, or context breakdowns in AI outputs."
-model = "gpt-5.4"
+model = "gpt-5.6-sol"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/categories/13-llmops-evals-observability/prompt-regression-tester.toml
+++ b/categories/13-llmops-evals-observability/prompt-regression-tester.toml
@@ -1,6 +1,6 @@
 name = "prompt-regression-tester"
 description = "Use when a task needs regression coverage for prompt, model, tool, or workflow changes in an AI system."
-model = "gpt-5.3-codex-spark"
+model = "gpt-5.6-terra"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 developer_instructions = """

--- a/presets/everyday-development.txt
+++ b/presets/everyday-development.txt
@@ -1,0 +1,16 @@
+# A focused global set for normal software development.
+categories/01-core-development/code-mapper.toml
+categories/01-core-development/backend-developer.toml
+categories/01-core-development/frontend-developer.toml
+categories/04-quality-security/debugger.toml
+categories/04-quality-security/reviewer.toml
+categories/04-quality-security/test-automator.toml
+categories/06-developer-experience/refactoring-specialist.toml
+categories/06-developer-experience/dependency-manager.toml
+categories/06-developer-experience/git-workflow-manager.toml
+categories/10-research-analysis/docs-researcher.toml
+categories/09-meta-orchestration/graph-context-curator.toml
+categories/09-meta-orchestration/graph-planner.toml
+categories/09-meta-orchestration/graph-router.toml
+categories/09-meta-orchestration/graph-verifier.toml
+categories/09-meta-orchestration/graph-worker.toml

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,124 @@
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/.." && pwd)
+
+scope=global
+preset=everyday
+force=false
+dry_run=false
+
+usage() {
+    printf '%s\n' \
+        "Usage: $0 [--scope global|project] [--preset everyday|all] [--force] [--dry-run]" \
+        "" \
+        "Defaults to the everyday preset in the global Codex agents directory."
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --scope)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            scope=$2
+            shift 2
+            ;;
+        --preset)
+            [ "$#" -ge 2 ] || { usage >&2; exit 2; }
+            preset=$2
+            shift 2
+            ;;
+        --force)
+            force=true
+            shift
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            printf 'Unknown option: %s\n' "$1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+case "$scope" in
+    global)
+        codex_root=${CODEX_HOME:-"${HOME}/.codex"}
+        destination=$codex_root/agents
+        ;;
+    project)
+        destination=$(pwd)/.codex/agents
+        ;;
+    *)
+        printf 'Invalid scope: %s\n' "$scope" >&2
+        exit 2
+        ;;
+esac
+
+case "$preset" in
+    everyday)
+        source_list=$repo_root/presets/everyday-development.txt
+        ;;
+    all)
+        source_list=
+        ;;
+    *)
+        printf 'Invalid preset: %s\n' "$preset" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$dry_run" = false ]; then
+    mkdir -p "$destination"
+fi
+
+installed=0
+skipped=0
+
+install_one() {
+    relative_path=$1
+    source_file=$repo_root/$relative_path
+    target_file=$destination/$(basename -- "$relative_path")
+
+    if [ ! -f "$source_file" ]; then
+        printf 'Missing source: %s\n' "$relative_path" >&2
+        exit 1
+    fi
+
+    if [ -e "$target_file" ] && [ "$force" = false ]; then
+        printf 'skip     %s (already exists)\n' "$target_file"
+        skipped=$((skipped + 1))
+        return
+    fi
+
+    if [ "$dry_run" = true ]; then
+        printf 'would install %s\n' "$target_file"
+    else
+        cp "$source_file" "$target_file"
+        printf 'installed %s\n' "$target_file"
+    fi
+    installed=$((installed + 1))
+}
+
+if [ "$preset" = everyday ]; then
+    while IFS= read -r relative_path || [ -n "$relative_path" ]; do
+        case "$relative_path" in
+            ''|'#'*) continue ;;
+        esac
+        install_one "$relative_path"
+    done < "$source_list"
+else
+    for source_file in "$repo_root"/categories/*/*.toml; do
+        relative_path=${source_file#"$repo_root/"}
+        install_one "$relative_path"
+    done
+fi
+
+printf 'Done: %s selected, %s skipped. Destination: %s\n' "$installed" "$skipped" "$destination"

--- a/scripts/validate_agents.py
+++ b/scripts/validate_agents.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Validate Codex custom agent TOML files."""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+AGENT_FILES = sorted((ROOT / "categories").glob("*/*.toml"))
+REQUIRED = {
+    "name": str,
+    "description": str,
+    "developer_instructions": str,
+}
+ALLOWED_MODELS = {"gpt-5.6-sol", "gpt-5.6-terra"}
+ALLOWED_EFFORTS = {"low", "medium", "high", "xhigh", "max", "ultra"}
+ALLOWED_SANDBOXES = {"read-only", "workspace-write", "danger-full-access"}
+
+
+def validate(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        with path.open("rb") as handle:
+            data = tomllib.load(handle)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        return [f"invalid TOML: {exc}"]
+
+    for key, expected_type in REQUIRED.items():
+        value = data.get(key)
+        if not isinstance(value, expected_type) or not value.strip():
+            errors.append(f"{key} must be a non-empty {expected_type.__name__}")
+
+    if data.get("name") != path.stem:
+        errors.append(f"name must match filename: expected {path.stem!r}")
+
+    if data.get("model") not in ALLOWED_MODELS:
+        errors.append(f"unsupported model: {data.get('model')!r}")
+
+    if data.get("model_reasoning_effort") not in ALLOWED_EFFORTS:
+        errors.append(
+            f"unsupported model_reasoning_effort: "
+            f"{data.get('model_reasoning_effort')!r}"
+        )
+
+    if data.get("sandbox_mode") not in ALLOWED_SANDBOXES:
+        errors.append(f"unsupported sandbox_mode: {data.get('sandbox_mode')!r}")
+
+    return errors
+
+
+def main() -> int:
+    if not AGENT_FILES:
+        print("No agent files found.", file=sys.stderr)
+        return 1
+
+    failures = 0
+    names: dict[str, Path] = {}
+
+    for path in AGENT_FILES:
+        errors = validate(path)
+        try:
+            with path.open("rb") as handle:
+                name = tomllib.load(handle).get("name")
+        except (OSError, tomllib.TOMLDecodeError):
+            name = None
+
+        if isinstance(name, str) and name in names:
+            errors.append(f"duplicate name also used by {names[name].relative_to(ROOT)}")
+        elif isinstance(name, str):
+            names[name] = path
+
+        if errors:
+            failures += 1
+            relative = path.relative_to(ROOT)
+            for error in errors:
+                print(f"{relative}: {error}", file=sys.stderr)
+
+    if failures:
+        print(f"Validation failed: {failures}/{len(AGENT_FILES)} files", file=sys.stderr)
+        return 1
+
+    counts: dict[str, int] = {}
+    for path in AGENT_FILES:
+        with path.open("rb") as handle:
+            model = tomllib.load(handle)["model"]
+        counts[model] = counts.get(model, 0) + 1
+
+    summary = ", ".join(f"{model}={count}" for model, count in sorted(counts.items()))
+    print(f"Validated {len(AGENT_FILES)} agents ({summary}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- migrate all 172 existing agent definitions from `gpt-5.4` and
  `gpt-5.3-codex-spark` to role-appropriate `gpt-5.6-sol` and
  `gpt-5.6-terra`
- add five graph-engineering agents for planning, context curation, routing,
  bounded implementation, and independent verification
- add an everyday-development preset and safe global/project installer
- add a TOML validator for required fields, supported models, reasoning effort,
  sandbox modes, unique names, and filename alignment
- update the README for the current `developer_instructions` schema,
  installation flow, model routing, agent count, and validation command

## Why

The collection was pinned to older model IDs and its README still showed an
outdated instruction-table example. The new routing preserves separate quality
and speed roles while making a focused daily-development setup easy to install.
The graph agents add explicit dependency, retry, ownership, and verification
responsibilities for coordinated multi-agent workflows.

## Impact

Users can install a curated 15-agent daily-development set with one command, or
install all definitions. Existing destination files are preserved unless
`--force` is supplied.

## Validation

- `python3 scripts/validate_agents.py`
  - validated 177 agents
  - `gpt-5.6-sol`: 139
  - `gpt-5.6-terra`: 38
- `sh -n scripts/install.sh`
- installer dry-run for the everyday and all presets
- `git diff --check`
