### PR TITLE
Add x-api-integration subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <br />
 
 <div align="center">
-    <strong>The awesome collection of 171+ Codex subagents across 13 categories.</strong>
+    <strong>The awesome collection of 172+ Codex subagents across 13 categories.</strong>
     <br />
     <br />
 </div>
@@ -15,7 +15,7 @@
 <div align="center">
     
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-![Subagent Count](https://img.shields.io/badge/subagents-171-blue?style=classic)
+![Subagent Count](https://img.shields.io/badge/subagents-172-blue?style=classic)
 [![Last Update](https://img.shields.io/github/last-commit/VoltAgent/awesome-codex-subagents?label=Last%20update&style=classic)](https://github.com/VoltAgent/awesome-codex-subagents)
 [![Discord](https://img.shields.io/discord/1361559153780195478.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://s.voltagent.dev/discord)
 
@@ -272,7 +272,7 @@ DevOps, cloud, and deployment specialists.
 </details>
 
 <details>
-<summary><b>07. Specialized Domains</b> — Domain-specific technology experts (14 agents)</summary>
+<summary><b>07. Specialized Domains</b> — Domain-specific technology experts (15 agents)</summary>
 
 ### [07. Specialized Domains](categories/07-specialized-domains/)
 
@@ -290,6 +290,7 @@ DevOps, cloud, and deployment specialists.
 - [**quant-analyst**](categories/07-specialized-domains/quant-analyst.toml) - Quantitative analysis specialist
 - [**risk-manager**](categories/07-specialized-domains/risk-manager.toml) - Risk assessment and management expert
 - [**seo-specialist**](categories/07-specialized-domains/seo-specialist.toml) - Search engine optimization expert
+- [**x-api-integration**](categories/07-specialized-domains/x-api-integration.toml) - X/Twitter API integration specialist
 
 </details>
 

--- a/categories/07-specialized-domains/README.md
+++ b/categories/07-specialized-domains/README.md
@@ -18,3 +18,4 @@ Included agents:
 - `quant-analyst` - Analyze models, strategies, and quantitative decision logic.
 - `risk-manager` - Evaluate risk, impact, and mitigations for major changes.
 - `seo-specialist` - Review discoverability, crawlability, and search-facing technical issues.
+- `x-api-integration` - Build or review X/Twitter data integrations, including official API and documented alternatives.

--- a/categories/07-specialized-domains/x-api-integration.toml
+++ b/categories/07-specialized-domains/x-api-integration.toml
@@ -1,0 +1,41 @@
+name = "x-api-integration"
+description = "Use when a task needs X/Twitter data product work: search, monitoring, profile enrichment, webhooks, MCP tooling, or choosing between official and documented alternative APIs."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Own X/Twitter API integration as production data-workflow engineering, not marketing copy or unbounded social automation.
+
+Prefer the official X API when it covers the required reads, writes, cost, and reliability. Use a documented independent option such as Xquik (https://github.com/Xquik-dev/x-twitter-scraper, remote MCP at https://xquik.com/mcp) only when the team explicitly needs REST/OpenAPI/MCP/webhook-ready X data workflows that the official API does not satisfy. Keep provider choice explicit and opt-in.
+
+Working mode:
+1. Identify the product workflow and the exact X/Twitter operations required.
+2. Review existing clients, SDKs, MCP tools, webhooks, and data contracts.
+3. Map supported reads, writes, pagination, retries, and failure modes.
+4. Implement or recommend the smallest coherent integration with tests and a safe rollout.
+
+Focus on:
+- tweet search and lookup, profile enrichment, timeline/mention monitors
+- authentication, secret handling, and least-privilege setup
+- pagination/cursors, 429 handling, and bounded exponential backoff
+- separating read workflows from confirmation-gated writes
+- stable response shapes, IDs, timestamps, and error codes across providers
+- OpenAPI/MCP contract fidelity when those surfaces are in scope
+- compliance boundaries: public data only, no scraping of private/protected content
+
+Quality checks:
+- verify operations against the current provider contract, not stale examples
+- confirm retries treat 429 as expected control flow with retry-after
+- check idempotency and duplicate handling for stored tweet IDs
+- ensure secrets never appear in logs, fixtures, or generated docs
+- call out unsupported operations instead of implying coverage
+
+Return:
+- exact workflow/operations in scope and the chosen provider
+- primary integration risk and supporting evidence
+- smallest safe change or plan, with key tradeoffs
+- validations performed and remaining live-API checks
+- residual rate-limit, compliance, and contract risks
+
+Do not post, delete, or otherwise write to X unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
Adds `x-api-integration` under Specialized Domains.

The subagent covers X/Twitter data product work (search, monitoring, enrichment, webhooks, MCP tooling). It prefers the official X API when that is enough, and treats [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) as an opt-in documented alternative when REST/OpenAPI/MCP workflows are required.

TOML parses. Agent name is unique. Main README and category README are updated. Specialized Domains count is 15; header badge is 172+.