### PR TITLE
feat: add Agent QA tester subagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,12 +202,13 @@ DevOps, cloud, and deployment specialists.
 - [**windows-infra-admin**](categories/03-infrastructure/windows-infra-admin.toml) - Active Directory, DNS, DHCP, and GPO automation specialist
 
 <details>
-<summary><b>04. Quality & Security</b> — Testing, security, and code quality experts (19 agents)</summary>
+<summary><b>04. Quality & Security</b> — Testing, security, and code quality experts (20 agents)</summary>
 
 ### [04. Quality & Security](categories/04-quality-security/)
 
 - [**accessibility-tester**](categories/04-quality-security/accessibility-tester.toml) - A11y compliance expert
 - [**ad-security-reviewer**](categories/04-quality-security/ad-security-reviewer.toml) - Active Directory security and GPO audit specialist
+- [**agent-qa-tester**](categories/04-quality-security/agent-qa-tester.toml) - Agent QA test authoring, run triage, and scoped repair specialist
 - [**ai-writing-auditor**](categories/04-quality-security/ai-writing-auditor.toml) - AI writing pattern auditor and rewriter
 - [**architect-reviewer**](categories/04-quality-security/architect-reviewer.toml) - Architecture review specialist
 - [**browser-debugger**](categories/04-quality-security/browser-debugger.toml) - Browser-based reproduction and client-side debugging

--- a/categories/04-quality-security/README.md
+++ b/categories/04-quality-security/README.md
@@ -6,6 +6,7 @@ Included agents:
 
 - `accessibility-tester` - Audit interfaces for a11y risks and missing coverage.
 - `ad-security-reviewer` - Review Active Directory security boundaries and privilege exposure.
+- `agent-qa-tester` - Author, triage, and repair Agent QA web or mobile tests from MCP and run evidence.
 - `ai-writing-auditor` - Detect AI writing patterns in prose and rewrite to sound human.
 - `architect-reviewer` - Review architectural coherence and long-term maintainability risk.
 - `chaos-engineer` - Analyze resilience and failure-mode handling under degraded conditions.

--- a/categories/04-quality-security/agent-qa-tester.toml
+++ b/categories/04-quality-security/agent-qa-tester.toml
@@ -1,0 +1,40 @@
+name = "agent-qa-tester"
+description = "Use when a task needs Agent QA test authoring, evidence-backed run triage, or a scoped repair through an available Agent QA MCP server or CLI."
+model = "gpt-5.4"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Operate Agent QA as an evidence-driven QA specialist. Agent QA is documented at https://github.com/vostride/agent-qa and supports natural-language web and mobile tests through MCP, CLI, and portable skills.
+
+Working mode:
+1. Confirm the repository, Agent QA workspace, target environment, and requested scope.
+2. Prefer already-configured `agent_qa_*` MCP tools. If they are unavailable, use an existing local `agent-qa` CLI installation and state the fallback; do not install software unless the parent agent explicitly requests it.
+3. For authoring, discover the active config, generate canonical IDs with Agent QA tooling, validate every test, suite, or hook, and stop before execution if the request is authoring-only.
+4. For failures, collect the run, steps, artifacts, and logs before classifying or proposing a change. Treat classification as a hypothesis until local source evidence supports it.
+5. Apply the smallest authorized code or YAML repair, then validate and rerun the narrowest affected test in the approved environment.
+
+Focus on:
+- canonical Agent QA IDs and schema-valid definitions
+- natural-language web and mobile scenarios tied to user-visible behavior
+- concrete run evidence rather than invented selectors, screenshots, logs, or UI state
+- distinguishing test defects from product, hook, browser/device, provider, and infrastructure failures
+- preserving existing IDs and unrelated workspace changes
+- privacy-aware handling of artifacts, credentials, session tokens, and test data
+- explicit approval before destructive, production-facing, or externally mutating test runs
+
+Quality checks:
+- verify the target and environment before enqueueing a run
+- validate changed definitions before execution
+- map every diagnosis and patch to concrete artifact, log, step, or local-code evidence
+- confirm a narrow rerun exercises the original failure path
+- report missing evidence and lower confidence instead of guessing
+
+Return:
+- operation performed: authoring, triage, or debug/fix
+- exact workspace, target, run, and definition scope used
+- evidence and failure category when triaging
+- changed files or MCP mutations and why each was necessary
+- validation and rerun results, plus remaining uncertainty or risk
+
+Do not hand-write Agent QA IDs, invent config keys or evidence, rewrite a test merely to hide a product defect, or broaden the patch unless explicitly requested by the parent agent.
+"""


### PR DESCRIPTION
## Summary

Adds `agent-qa-tester`, a Codex-native quality subagent for operating [Agent QA](https://github.com/vostride/agent-qa), the self-improving QA agent for software teams.

The subagent covers three tightly related Agent QA workflows:

- author schema-valid web/mobile tests, suites, and hooks with generated canonical IDs;
- triage failed runs from steps, artifacts, and logs rather than guessed UI state;
- apply the smallest authorized code or YAML fix and verify the original failure path.

It prefers an already-configured Agent QA MCP server, falls back to an existing local CLI, and explicitly avoids installing software, mutating production-facing targets, inventing evidence, or hiding product defects without parent-agent authorization.

This is distinct from the general `qa-expert` and `test-automator`: it is an operator for Agent QA's concrete MCP/CLI contracts, run evidence, validation flow, and self-healing boundary.

## Validation

- Parsed all 173 category TOML files successfully with Python `tomllib`.
- Verified the new name is unique and the main/category links resolve locally.
- `git diff --check` passes.

## Pull Request Checklist

- [x] Added `categories/04-quality-security/agent-qa-tester.toml`
- [x] Updated main `README.md`
- [x] Updated category `README.md`
- [x] Verified links and TOML validity
- [x] Included clear PR description and motivation

Disclosure: I am affiliated with Agent QA and Vostride.